### PR TITLE
Enhancement/ux 320

### DIFF
--- a/src/js/components/modal/modalview.js
+++ b/src/js/components/modal/modalview.js
@@ -230,7 +230,7 @@ ModalView.propTypes = {
     ]),
     result: PropTypes.string,
     title: PropTypes.string,
-    closeOnEscapeKey: PropTypes.bool
+    ignoreEscapeKey: PropTypes.bool
 };
 
 export {


### PR DESCRIPTION
Adds an event handler for escape to close the modal. A further extension might be to allow key event functions to be passed into the modal at definition time.

@sophistifunk 
