### PR TITLE
[UX-445] add support for "tight spacing" in empty state

### DIFF
--- a/less/components/empty-state.less
+++ b/less/components/empty-state.less
@@ -10,6 +10,7 @@
     max-width: 80rem;
     padding: 4rem 4rem;
     margin: 2rem 4rem;
+    border-radius: 2px;
     background-color: @brand-success-lite;
 
     .empty-state-icon {
@@ -36,6 +37,10 @@
       button {
         .btn-styles(transparent, white, white);
       }
+    }
+
+    &.tight-spacing {
+      padding: 0.5rem 0;
     }
   }
 }

--- a/src/js/components/EmptyStateView.jsx
+++ b/src/js/components/EmptyStateView.jsx
@@ -6,23 +6,27 @@ import {EmptyStateIcon} from './EmptyStateIcon';
 /**
  * Displays an "empty state" dialog with arbitrary child content and an optional icon.
  *
- * Content in the follow form will recent nice default styles:
+ * Content in the following form will recent nice default styles:
  *
  * <h1>Title<h1>
  * <p>A longer message...</p>
  * <button>Take Action!</button> *
  *
- * Attribute: iconName="branch|goat|shoes"
+ * Properties:
+ * iconName="branch|goat|shoes"
+ * tightSpacing={true|false}
  */
 export class EmptyStateView extends Component {
-    constructor() {
-        super();
-    }
-
     render() {
+        let layoutClasses = 'empty-state-container';
+
+        if (this.props.tightSpacing) {
+            layoutClasses = `${layoutClasses} tight-spacing`;
+        }
+
         return (
             <div className="empty-state">
-                <div className="empty-state-container">
+                <div className={layoutClasses}>
                     { this.props.iconName ? <EmptyStateIcon name={this.props.iconName} /> : null }
                     <div className="empty-state-content">{this.props.children}</div>
                 </div>
@@ -33,4 +37,5 @@ export class EmptyStateView extends Component {
 
 EmptyStateView.propTypes = {
     iconName: PropTypes.oneOf(['branch','goat','shoes']),
+    tightSpacing: PropTypes.bool,
 };

--- a/src/js/stories/emptystateview.jsx
+++ b/src/js/stories/emptystateview.jsx
@@ -3,10 +3,19 @@ import { storiesOf } from '@kadira/storybook';
 import { EmptyStateView } from '../components/EmptyStateView';
 
 storiesOf('EmptyStateView', module)
+    .add('One-Liner', oneLiner)
     .add('Content & Wide Image', contentWithWideImage)
     .add('Content & Narrow Image', contentWithNarrowImage)
     .add('Content Only', contentOnly)
     .add('Image Only', imageOnly);
+
+function oneLiner() {
+    return (
+        <EmptyStateView tightSpacing={true}>
+            <p>There are no artifacts for this pipeline run.</p>
+        </EmptyStateView>
+    );
+}
 
 function contentWithWideImage() {
     return (


### PR DESCRIPTION
Related to issue # UX-445

Summary of changes:
- Make empty state view a bit more flexible in terms of spacing

I expect once we nail down all the permutations of this thing we can refactor the props API to something cleaner. I know there's a new background color coming in another ticket.

@reviewbybees 
