### PR TITLE
Feature/ux 493 take2 - fix issues with modal layout / scrollbar

### DIFF
--- a/less/components/pipeline-result.less
+++ b/less/components/pipeline-result.less
@@ -1,5 +1,6 @@
 .pipeline-result {
   width: 100%;
+  display: flex;
   font-family: @font-family-panel;
   color: #ffffff;
 
@@ -8,8 +9,12 @@
     padding-bottom: 5px;
   }
 
-  .left svg {
+  .status svg {
     margin: -15px 10px 0 -15px;
+  }
+
+  .table {
+    flex-grow: 1;
   }
 
   .row {

--- a/less/theme.less
+++ b/less/theme.less
@@ -714,6 +714,7 @@ footer {
 .dialog {
   width: 100%;
   height: 100%;
+  min-width: 640px; // avoid flow issues when resizing dialogs very small
   position: fixed;
   top: 0;
   left: 0;
@@ -726,15 +727,17 @@ footer {
 }
 
 .dialog .header {
-  padding: 25px 50px 0 50px;
   color: #ffffff;
   font-weight: normal;
   line-height: 20px;
   font-size: 1.6rem;
 }
 
+.dialog .header-content {
+  padding: 25px 50px 0 50px;
+}
+
 .dialog .header .page-tabs {
-  clear: both;
   font-size: 1.5rem;
 
   a {

--- a/src/js/components/modal/modalview.js
+++ b/src/js/components/modal/modalview.js
@@ -172,9 +172,11 @@ class ModalView extends Component {
                            role="button"
                            className="closeButton"
                            style={closeButtonStyle}>&times;</a>
+                        <div className="header-content">
                         {
                             head && head[0] ? head : <Header {...titleStyle} {...rest}/>
                         }
+                        </div>
                     </div>
                     <div className="content" style={contentStyle}>
                         {

--- a/src/js/components/pipeResult/Result.jsx
+++ b/src/js/components/pipeResult/Result.jsx
@@ -41,7 +41,7 @@ class PipelineResult extends Component {
 
         return (
         <div className="pipeline-result">
-            <section className="left">
+            <section className="status">
                 <Icon {...{
                     size: 125,
                     icon: iconFromResult(result),


### PR DESCRIPTION
The modal view was having some finicky layout issues with the "content" area clipping off the end of its content (or not showing scrollbar at all, fixed in #25) and the "header" area having inconsistent / clipping layout due to use of float:left and padding on a position:fixed element.

Summary of changes:
- Basically using flexbox to make life better.

@reviewbybees 
