### PR TITLE
feature/UX-297 TimeDuration component

### DIFF
--- a/src/js/components/TimeDuration.jsx
+++ b/src/js/components/TimeDuration.jsx
@@ -1,0 +1,44 @@
+// @flow
+
+import React, {Component, PropTypes} from 'react';
+import moment from 'moment';
+require('moment-duration-format');
+
+const { number, oneOfType, string} = PropTypes;
+
+/**
+ * Displays a millisecond duration as text in moment-duration-format's "humanize()" format,
+ * e.g. "a few seconds", "2 hours", etc.
+ * Also displays tooltip with more precise duration in "mos, days, hours, mins, secs" format.
+ * Tooltip text can be overridden via "hint" property.
+ *
+ * Properties:
+ * "millis": number or string.
+ * "hint": string to use for tooltip.
+ */
+export class TimeDuration extends Component {
+    render() {
+        const millis = !isNaN(this.props.millis) ?
+            parseInt(this.props.millis) :
+            this.props.millis;
+
+        if (!isNaN(millis)) {
+            const duration = moment.duration(millis).humanize();
+
+            const hint = this.props.hint ?
+                this.props.hint :
+                moment.duration(millis).format("M [mos], d [days], h[h], m[m], s[s]");
+
+            return (
+                <span title={hint}>{duration}</span>
+            );
+        }
+
+        return (<span>-</span>);
+    }
+}
+
+TimeDuration.propTypes = {
+    millis: oneOfType([number, string]),
+    hint: string,
+};

--- a/src/js/components/TimeDuration.jsx
+++ b/src/js/components/TimeDuration.jsx
@@ -18,9 +18,7 @@ const { number, oneOfType, string} = PropTypes;
  */
 export class TimeDuration extends Component {
     render() {
-        const millis = !isNaN(this.props.millis) ?
-            parseInt(this.props.millis) :
-            this.props.millis;
+        const millis = parseInt(this.props.millis);
 
         if (!isNaN(millis)) {
             const duration = moment.duration(millis).humanize();

--- a/src/js/components/index.js
+++ b/src/js/components/index.js
@@ -28,3 +28,4 @@ export {EmptyStateIcon} from './EmptyStateIcon';
 export {PipelineGraph} from './PipelineGraph';
 export {FileSize} from './FileSize';
 export {Toast} from './Toast';
+export {TimeDuration} from './TimeDuration';

--- a/src/js/stories/index.jsx
+++ b/src/js/stories/index.jsx
@@ -3,5 +3,6 @@ require('./filesize.jsx');
 require('./modalview.jsx');
 require('./pipelinegraph.jsx');
 require('./pipelineresult.jsx');
-require('./toast.jsx');
 require('./statusIndicatorStories.jsx');
+require('./timeduration.jsx');
+require('./toast.jsx');

--- a/src/js/stories/timeduration.jsx
+++ b/src/js/stories/timeduration.jsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { action, storiesOf } from '@kadira/storybook';
+import { TimeDuration } from '../components/TimeDuration';
+
+storiesOf('TimeDuration', module)
+    .add('short duration', scenario1)
+    .add('long duration, all date parts', scenario2)
+    .add('with custom hint', scenario3)
+    .add('duration as string', scenario4)
+    .add('bad value', scenario5)
+    .add('undefined value', scenario6);
+
+function scenario1() {
+    return (
+        <TimeDuration millis={50000} />
+    );
+}
+
+function scenario2() {
+    return (
+        <TimeDuration millis={1000*60*60*24*7*4*6+1001*60*60*4.75} />
+    );
+}
+
+function scenario3() {
+    return (
+        <TimeDuration millis={50000} hint="Custom hint." />
+    );
+}
+
+function scenario4() {
+    return (
+        <TimeDuration millis="50000" />
+    );
+}
+
+function scenario5() {
+    return (
+        <TimeDuration millis="abcdefg" />
+    );
+}
+
+function scenario6() {
+    return (
+        <TimeDuration />
+    );
+}


### PR DESCRIPTION
Summary of changes:
* New component for expressing time durations, e.g. "2 minutes."
* Has a title "tooltip" that displays more precise duration such as "2 hrs, 52 mins, 45 secs"