### PR TITLE
Fix a couple of issues in PipelineGraph with duplicate node names

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@jenkins-cd/design-language",
     "jdlName": "jenkins-design-language",
-    "version": "0.0.46",
+    "version": "0.0.47-unpublished",
     "description": "Styles, assets, and React classes for Jenkins Design Language",
     "main": "dist/js/components/index.js",
     "scripts": {

--- a/src/js/components/PipelineGraph.jsx
+++ b/src/js/components/PipelineGraph.jsx
@@ -6,19 +6,6 @@ import {strokeWidth as nodeStrokeWidth} from './status/SvgSpinner';
 
 import type {Result} from './status/StatusIndicator';
 
-// See: io.jenkins.blueocean.rest.model.BlueRun.BlueRunState
-// See: io.jenkins.blueocean.rest.model.BlueRun.BlueRunResult
-export const pipelineStageState:{ [key: string]: Result } = {
-    // TODO: Replace use of this exported const with StatusIndicator.validResultValues in BO tests
-    queued: "queued", // May run in future
-    running: "running",
-    success: "success",
-    failure: "failure",
-    aborted: "aborted",
-    unstable: "unstable",
-    notBuilt: "not_built" // Not run, and will not be
-};
-
 // Dimensions used for layout, px
 export const defaultLayout = {
     nodeSpacingH: 120,
@@ -53,6 +40,7 @@ type ConnectionInfo = [NodeInfo, NodeInfo];
 type LabelInfo = {
     x: number,
     y: number,
+    nodeId: string,
     text: string
 };
 
@@ -157,7 +145,8 @@ export class PipelineGraph extends Component {
             bigLabels.push({
                 x: xp,
                 y: yp,
-                text: topStage.name
+                text: topStage.name,
+                nodeId: topStage.id
             });
 
             // If stage has children, we don't draw a node for it, just its children
@@ -183,7 +172,8 @@ export class PipelineGraph extends Component {
                     smallLabels.push({
                         x: xp,
                         y: yp,
-                        text: nodeStage.name
+                        text: nodeStage.name,
+                        nodeId: nodeStage.id
                     });
                 }
 
@@ -238,7 +228,9 @@ export class PipelineGraph extends Component {
             left: x + "px"
         });
 
-        return <div className="pipeline-big-label" style={style} key={details.text}>{details.text}</div>;
+        const key = details.nodeId + '-big';
+
+        return <div className="pipeline-big-label" style={style} key={key}>{details.text}</div>;
     }
 
     createSmallLabel(details: LabelInfo) {
@@ -269,7 +261,9 @@ export class PipelineGraph extends Component {
             left: x
         });
 
-        return <div className="pipeline-small-label" style={style} key={details.text}>{details.text}</div>;
+        const key = details.nodeId + '-big';
+
+        return <div className="pipeline-small-label" style={style} key={key}>{details.text}</div>;
     }
 
     renderConnection(connection: ConnectionInfo) {
@@ -347,7 +341,7 @@ export class PipelineGraph extends Component {
                         className="pipeline-node-hittarget"
                         fillOpacity="0"
                         stroke="none"
-                        onClick={() => this.props.onNodeClick(node.name)}/>
+                        onClick={() => this.props.onNodeClick(node.name, node.id)}/>
             );
         }
 

--- a/src/js/stories/pipelinegraph.jsx
+++ b/src/js/stories/pipelinegraph.jsx
@@ -1,5 +1,5 @@
 import React, {Component, PropTypes} from 'react';
-import { action, storiesOf } from '@kadira/storybook';
+import { storiesOf } from '@kadira/storybook';
 import {PipelineGraph, defaultLayout} from '../components/PipelineGraph';
 
 import { StatusIndicator } from '../components';
@@ -7,6 +7,7 @@ const pipelineStageState = StatusIndicator.validResultValues;
 
 storiesOf('PipelineGraph', module)
     .add('Mixed', renderMultiParallelPipeline)
+    .add('Duplicate Names', renderWithDuplicateNames)
     .add('Fat', renderFlatPipelineFat)
     .add('Legend', renderFlatPipeline)
     .add('Constructor', renderConstructomatic)
@@ -33,6 +34,27 @@ function renderFlatPipeline() {
     const layout = { nodeSpacingH: 90 };
 
     return <div><PipelineGraph stages={stages} layout={layout}/></div>;
+}
+
+function renderWithDuplicateNames() {
+
+    const stages = [
+        makeNode("Build"),
+        makeNode("Test"),
+        makeNode("Browser Tests", [
+            makeNode("Internet Explorer"),
+            makeNode("Chrome")
+        ]),
+        makeNode("Test"),
+        makeNode("Staging"),
+        makeNode("Production")
+    ];
+
+    return (
+        <div>
+            <PipelineGraph stages={stages}/>
+        </div>
+    );
 }
 
 function renderFlatPipelineFat() {
@@ -108,12 +130,18 @@ function renderListenersPipeline() {
             makeNode("Chrome", [], pipelineStageState.queued)
         ]),
         makeNode("Dev"),
+        makeNode("Dev"), // Make sure it works with dupe names
         makeNode("Staging"),
         makeNode("Production")
     ];
 
-    return <div><PipelineGraph stages={stages} onNodeClick={nodeName => action('Clicked', nodeName)}/></div>;
+    function nodeClicked(...values) {
+        console.log('Node clicked', values);
+    }
+
+    return <div><PipelineGraph stages={stages} onNodeClick={nodeClicked}/></div>;
 }
+
 function renderParallelPipeline() {
 
     const stages = [


### PR DESCRIPTION
* Allow duplicate stage/node names in PipelineGraph
* Return id as well as name for onNodeClick
* Update stories

@reviewbybees 