### PR TITLE
bug/jenkins 36102 - tabs clipped safari

### DIFF
--- a/less/theme.less
+++ b/less/theme.less
@@ -832,6 +832,12 @@ footer {
     }
 }
 
+@supports (overflow:-webkit-marquee) and (justify-content:inherit) {
+    .dialog .header .page-tabs {
+        margin-bottom: 22px;
+    }
+}
+
 .dialog .header {
     &.success {
         background-color: @brand-success;

--- a/less/theme.less
+++ b/less/theme.less
@@ -832,6 +832,7 @@ footer {
     }
 }
 
+// force the parent container of the tabs taller to avoid clipping in Safari 9+
 @supports (overflow:-webkit-marquee) and (justify-content:inherit) {
     .dialog .header .page-tabs {
         margin-bottom: 22px;

--- a/less/theme.less
+++ b/less/theme.less
@@ -687,13 +687,6 @@ code.hash {
     transform: translateZ(0);
 }
 
-// Applies this style to safari 9.0+
-@supports (overflow:-webkit-marquee) and (justify-content:inherit) {
-    .page-tabs a {
-        margin-bottom: 0px;
-    }
-}
-
 .page-tabs a:before {
     // For transforming underline
     content: "";
@@ -836,7 +829,6 @@ footer {
 
     a {
         letter-spacing: 1.1px;
-        margin-bottom: -4px;
     }
 }
 


### PR DESCRIPTION
Related to issue # JENKINS-36102

Summary of changes
* Fix a recent regression where the Run Details tabs were being clipped in Chrome / Firefox
* Fix a longer-standing bug where the tabs were severely clipped in Safari

@reviewbybees 