### PR TITLE
feature/JENKINS-35828 - status colors

### DIFF
--- a/less/theme.less
+++ b/less/theme.less
@@ -116,7 +116,7 @@ main {
 .status-color(failure, @brand-danger, @brand-danger-lite);
 .status-color(aborted, @brand-danger, @brand-danger-lite);
 .status-color(unstable, @brand-warning, @brand-warning-lite);
-.status-color(not-built, @brand-grey, @brand-grey-lite);
+.status-color(not_built, @brand-grey, @brand-grey-lite);
 .status-color(unknown, @brand-unknown, @brand-unknown-lite);
 
 .label-danger {

--- a/less/theme.less
+++ b/less/theme.less
@@ -79,6 +79,46 @@ h6 {
 main {
 }
 
+// creates a series of classes to allow reuse of common brand colors
+// e.g. status-color(haze, purple, fuchsia) yields:
+//  .haze-bg         --> background-color: purple;
+//  .haze-fill       --> fill: purple;
+//  .haze-color      --> color: purple;
+//  .haze-bg-lite    --> background-color: fuchsia;
+//  .haze-fill-lite  --> fill: fuchsia;
+//  .haze-color-lite --> color: fuchsia;
+
+.status-color(@status, @color, @color-lite) {
+    .@{status}-bg {
+        background-color: @color;
+    }
+    .@{status}-bg-lite {
+        background-color: @color-lite;
+    }
+    .@{status}-fill {
+        fill: @color;
+    }
+    .@{status}-fill-lite {
+        fill: @color-lite;
+    }
+    .@{status}-color {
+        color: @color;
+    }
+    .@{status}-color-lite {
+        color: @color-lite;
+    }
+}
+
+.status-color(success, @brand-success, @brand-success-lite);
+.status-color(info, @brand-info, @brand-info-lite);
+.status-color(queued, @brand-info, @brand-info-lite);
+.status-color(running, @brand-info, @brand-info-lite);
+.status-color(failure, @brand-danger, @brand-danger-lite);
+.status-color(aborted, @brand-danger, @brand-danger-lite);
+.status-color(unstable, @brand-warning, @brand-warning-lite);
+.status-color(not-built, @brand-grey, @brand-grey-lite);
+.status-color(unknown, @brand-unknown, @brand-unknown-lite);
+
 .label-danger {
     background-color: @brand-danger;
 }

--- a/less/theme.less
+++ b/less/theme.less
@@ -80,7 +80,7 @@ main {
 }
 
 // creates a series of classes to allow reuse of common brand colors
-// e.g. status-color(haze, purple, fuchsia) yields:
+// .status-color(haze, purple, fuchsia) yields:
 //  .haze-bg         --> background-color: purple;
 //  .haze-fill       --> fill: purple;
 //  .haze-color      --> color: purple;


### PR DESCRIPTION
Related to issue #JENKINS-35828

Summary of Changes:
* Add some generic classes for setting fill, background-color or color of an element in either normal or light theme color, based off result/status name. This should help us avoid having to remap our brand colors to numerous different classes.