### PR TITLE
[JENKINS-36701] add some validation to end of the gulp build

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -5,6 +5,7 @@
  */
 
 const gulp = require('gulp');
+const gutil = require('gulp-util');
 const fs = require('fs');
 const sourcemaps = require('gulp-sourcemaps');
 const babel = require('gulp-babel');
@@ -209,10 +210,11 @@ gulp.task("validate", () => {
     ];
 
     for (const path of paths) {
-        fs.stat(path, (err) => {
-            if (err != null) {
-                throw err;
-            }
-        });
+        try {
+            fs.statSync(path);
+        } catch (err) {
+            gutil.log('Error occurred during validation; see stack trace for details');
+            throw err;
+        }
     }
 });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -5,6 +5,7 @@
  */
 
 const gulp = require('gulp');
+const fs = require('fs');
 const sourcemaps = require('gulp-sourcemaps');
 const babel = require('gulp-babel');
 const concat = require('gulp-concat');
@@ -87,12 +88,12 @@ gulp.task("watch-styles", ["clean-build"], () => {
 // Default to all
 
 gulp.task("default", () =>
-    runSequence("clean", "lint", "test", "build"));
+    runSequence("clean", "lint", "test", "build", "validate"));
 
 // Clean and build only, for watching
 
 gulp.task("clean-build", () =>
-    runSequence("clean", "build"));
+    runSequence("clean", "build", "validate"));
 
 // Clean
 
@@ -197,3 +198,21 @@ gulp.task("copy-licenses-octicons", () =>
 gulp.task("copy-licenses-ofl", () =>
     gulp.src(config.copy.licenses_ofl.sources)
         .pipe(copy(config.copy.licenses_ofl.dest, {prefix: 1})));
+
+// Validate contents
+
+gulp.task("validate", () => {
+    const paths = [
+        config.less.dest,
+        config.copy.fonts.dest,
+        config.copy.octicons.dest,
+    ];
+
+    for (const path of paths) {
+        fs.stat(path, (err) => {
+            if (err != null) {
+                throw err;
+            }
+        });
+    }
+});


### PR DESCRIPTION
**Decription**
* JDL was published without octicons because npm install hadn't been run recently on publisher's machine. To defend against that, I added some validation to end of the gulp build, asserting that a few important directories are there
* Tested locally, no easy way to write a test for the build :P

**Submitter checklist**
- [x] Change is code complete and matches issue description
- [x] Apppropriate unit or acceptance tests or explaination to why this change has no tests

**Reviewer checklist**
- [ ] Run the changes and verified the change matches the issue description
- [x] Reviewed the code
- [x] Verified that the appropriate tests have been written or valid explaination given

@reviewbybees 