### PR TITLE
[JENKINS-36169] Fix offset for logs until <10k. For bigger logs you s…

### DIFF
--- a/less/components/result-status.less
+++ b/less/components/result-status.less
@@ -220,7 +220,6 @@
     background-color: @pre-bg;
     color: @pre-color;
     padding: 0.5em;
-    border-left: solid 28px darken(@pre-bg, 5%);
     margin-bottom: 1px;
 }
 

--- a/less/components/result-status.less
+++ b/less/components/result-status.less
@@ -221,6 +221,7 @@
     color: @pre-color;
     padding: 0.5em;
     margin-bottom: 1px;
+    border-left: solid 28px darken(@pre-bg, 5%);
 }
 
 // Expand animation

--- a/less/theme.less
+++ b/less/theme.less
@@ -592,7 +592,7 @@ code p::before {
     color: @gray-light;
     content: counter(line);
     float: left;
-    min-width: 20px;
+    min-width: 30px; // scales < 10k then you will see an offset
     white-space: nowrap;
     padding-right: 1em;
     padding-left: 10px;

--- a/less/theme.less
+++ b/less/theme.less
@@ -592,7 +592,7 @@ code p::before {
     background-color: @brand-grey;
     color: @gray-light;
     content: counter(line);
-    min-width: 30px; // scales < 10k then you will see an offset
+    min-width: 35px; // scales < 100k then you will see an offset
     white-space: nowrap;
     padding-right: 1em;
     padding-left: 10px;

--- a/less/theme.less
+++ b/less/theme.less
@@ -589,6 +589,7 @@ code a:hover {
 }
 
 code p::before {
+    background-color: @brand-grey;
     color: @gray-light;
     content: counter(line);
     float: left;

--- a/less/theme.less
+++ b/less/theme.less
@@ -592,7 +592,6 @@ code p::before {
     background-color: @brand-grey;
     color: @gray-light;
     content: counter(line);
-    float: left;
     min-width: 30px; // scales < 10k then you will see an offset
     white-space: nowrap;
     padding-right: 1em;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jenkins-cd/design-language",
   "jdlName": "jenkins-design-language",
-  "version": "0.0.65-unpublished",
+  "version": "0.0.65-thor",
   "description": "Styles, assets, and React classes for Jenkins Design Language",
   "main": "dist/js/components/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jenkins-cd/design-language",
   "jdlName": "jenkins-design-language",
-  "version": "0.0.65-thor",
+  "version": "0.0.65-thor2",
   "description": "Styles, assets, and React classes for Jenkins Design Language",
   "main": "dist/js/components/index.js",
   "scripts": {


### PR DESCRIPTION
**Decription**
General bug ATM with line padding >999 (log line moves to the right)

BEFORE
![screenshot from 2016-07-25 14-25-42](https://cloud.githubusercontent.com/assets/596701/17101297/10003d04-5274-11e6-8730-b25c035e149b.png)

AFTER
![screenshot from 2016-07-25 14-24-25](https://cloud.githubusercontent.com/assets/596701/17101314/1e370ac4-5274-11e6-9040-13cfac48b6ff.png)


**Submitter checklist**
- [x] Change is code complete and matches issue description
- [x] Apppropriate unit or acceptance tests or explaination to why this change has no tests

**Reviewer checklist**
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explaination given

@reviewbybees 

For bigger logs >10k you still see the offset bug. @i386 what should we do in this cases?

![screenshot from 2016-07-25 14-24-39](https://cloud.githubusercontent.com/assets/596701/17101322/25d305a8-5274-11e6-9f17-517c73e75cf4.png)
