### PR TITLE
[JENKINS-37023] stop propagation of click events outside the Favorite…

### DIFF
--- a/src/js/components/favorite/Favorite.jsx
+++ b/src/js/components/favorite/Favorite.jsx
@@ -48,7 +48,9 @@ export class Favorite extends Component {
 
     render() {
         return (
-            <label className={`checkbox ${this.props.className}`}>
+            <label className={`checkbox ${this.props.className}`}
+              onClick={(event) => event.stopPropagation()}
+            >
                 <input type="checkbox"
                        onChange={this.toggle.bind(this)}
                        checked={this.state.checked} />


### PR DESCRIPTION
**Description**
* Add a stopPropagation() call on the click event so that Favorite will consume it.

**Submitter checklist**
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests

**Reviewer checklist**
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

@reviewbybees