### PR TITLE
Feature/jenkins 36199 toaster

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 4
+end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_newline = true
+max_line_length = 160
+
+[*.md]
+trim_trailing_whitespace = false

--- a/less/components/toast.less
+++ b/less/components/toast.less
@@ -1,59 +1,83 @@
+.toaster {
+    width: 100%;
+    height: 100%;
+
+    .toast {
+        margin-bottom: 10px;
+    }
+
+    // the css-transitions-group container that toasts are added to
+    // lay out children from bottom to top, clipping if too many
+    > span {
+        width: 100%;
+        height: 100%;
+        display: flex;
+        flex-direction: column-reverse;
+        justify-content: flex-start;
+        align-items: flex-start;
+        overflow-y: hidden;
+    }
+}
+
 .toast {
-  display: inline-flex;
-  max-width: 350px;
-  background-color: @text-color;
-  padding: 20px;
-  border-radius: @border-radius-base;
-  /* TODO: get proper values from updated sketch file */
-  .box-shadow(1px 2px 2px rgba(0, 0, 0, .5));
+    display: inline-flex;
+    max-width: 350px;
+    flex-shrink: 0;
+    padding: 20px;
+    background-color: @text-color;
+    border-radius: @border-radius-base;
+    /* TODO: get proper values from updated sketch file */
+    .box-shadow(1px 2px 2px rgba(0, 0, 0, .5));
 
-  .text, .action, .dismiss {
-    align-self: center;
-  }
-
-  .text {
-    font-family: @font-family-ss-medium;
-    color: white;
-    max-height: 85px; // 5 lines @ line-height: 17px
-    overflow: hidden;
-  }
-
-  .action, .dismiss {
-    cursor: pointer;
-
-    &:hover {
-      text-decoration: none;
+    .text, .action, .dismiss {
+        align-self: center;
     }
-  }
 
-  .action {
-    margin: 0 20px;
-    text-transform: uppercase;
-  }
-
-  .dismiss {
-    color: white;
-
-    svg {
-      vertical-align: middle;
+    .text {
+        font-family: @font-family-ss-medium;
+        color: white;
+        max-height: 85px; // 5 lines @ line-height: 17px
+        overflow: hidden;
     }
-  }
+
+    .action, .dismiss {
+        cursor: pointer;
+
+        &:hover {
+            text-decoration: none;
+        }
+    }
+
+    .action {
+        margin: 0 20px;
+        text-transform: uppercase;
+    }
+
+    .dismiss {
+        color: white;
+
+        svg {
+            vertical-align: middle;
+        }
+    }
 }
 
 .toast-enter, .toast-appear {
-  opacity: 0.01;
+    opacity: 0.01;
 }
 
 .toast-enter.toast-enter-active, .toast-appear.toast-appear-active {
-  opacity: 1;
-  transition: opacity 300ms ease-in;
+    opacity: 1;
+    transition: all 300ms ease-in;
 }
 
 .toast-leave {
-  opacity: 1;
+    opacity: 1;
+    max-height: 150px;
 }
 
 .toast-leave.toast-leave-active {
-  opacity: 0.01;
-  transition: opacity 300ms ease-in;
+    opacity: 0.01;
+    max-height: 0;
+    transition: all 300ms ease-in;
 }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -51,7 +51,8 @@
       "dependencies": {
         "acorn": {
           "version": "2.7.0",
-          "from": "acorn@>=2.1.0 <3.0.0"
+          "from": "acorn@2.7.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz"
         }
       }
     },
@@ -589,7 +590,8 @@
       "dependencies": {
         "core-js": {
           "version": "2.4.0",
-          "from": "core-js@>=2.4.0 <3.0.0"
+          "from": "core-js@2.4.0",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.0.tgz"
         }
       }
     },
@@ -630,7 +632,8 @@
       "dependencies": {
         "core-js": {
           "version": "2.4.0",
-          "from": "core-js@>=2.4.0 <3.0.0"
+          "from": "core-js@2.4.0",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.0.tgz"
         }
       }
     },
@@ -760,7 +763,8 @@
       "dependencies": {
         "readable-stream": {
           "version": "2.0.6",
-          "from": "readable-stream@>=2.0.5 <2.1.0"
+          "from": "readable-stream@2.0.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
         }
       }
     },
@@ -811,7 +815,8 @@
         },
         "through2": {
           "version": "2.0.1",
-          "from": "through2@>=2.0.0 <3.0.0"
+          "from": "through2@2.0.1",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz"
         }
       }
     },
@@ -1298,7 +1303,8 @@
       "dependencies": {
         "clone": {
           "version": "0.2.0",
-          "from": "clone@>=0.2.0 <0.3.0"
+          "from": "clone@0.2.0",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
         },
         "object-assign": {
           "version": "2.1.1",
@@ -1319,7 +1325,8 @@
       "dependencies": {
         "clone": {
           "version": "0.2.0",
-          "from": "clone@>=0.2.0 <0.3.0"
+          "from": "clone@0.2.0",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
         },
         "object-assign": {
           "version": "2.1.1",
@@ -1340,7 +1347,8 @@
       "dependencies": {
         "readable-stream": {
           "version": "2.0.6",
-          "from": "readable-stream@>=2.0.0 <2.1.0"
+          "from": "readable-stream@2.0.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
         },
         "through2": {
           "version": "2.0.1",
@@ -1418,11 +1426,13 @@
       "dependencies": {
         "readable-stream": {
           "version": "2.0.6",
-          "from": "readable-stream@>=2.0.0 <2.1.0"
+          "from": "readable-stream@2.0.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
         },
         "through2": {
           "version": "2.0.1",
-          "from": "through2@>=2.0.0 <3.0.0"
+          "from": "through2@2.0.1",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz"
         }
       }
     },
@@ -1443,7 +1453,8 @@
       "dependencies": {
         "acorn": {
           "version": "1.2.2",
-          "from": "acorn@>=1.0.3 <2.0.0"
+          "from": "acorn@1.2.2",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
         }
       }
     },
@@ -1612,7 +1623,8 @@
         },
         "isarray": {
           "version": "0.0.1",
-          "from": "isarray@0.0.1"
+          "from": "isarray@0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
         }
       }
     },
@@ -2882,7 +2894,8 @@
       "dependencies": {
         "readable-stream": {
           "version": "2.0.6",
-          "from": "readable-stream@>=2.0.0 <2.1.0"
+          "from": "readable-stream@2.0.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
         },
         "through2": {
           "version": "2.0.1",
@@ -2898,11 +2911,13 @@
       "dependencies": {
         "object-assign": {
           "version": "3.0.0",
-          "from": "object-assign@>=3.0.0 <4.0.0"
+          "from": "object-assign@3.0.0",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
         },
         "readable-stream": {
           "version": "2.0.6",
-          "from": "readable-stream@>=2.0.0 <2.1.0"
+          "from": "readable-stream@2.0.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
         },
         "through2": {
           "version": "2.0.1",
@@ -2943,7 +2958,8 @@
       "dependencies": {
         "isarray": {
           "version": "0.0.1",
-          "from": "isarray@0.0.1"
+          "from": "isarray@0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
         }
       }
     },
@@ -3733,7 +3749,8 @@
       "dependencies": {
         "lodash.keys": {
           "version": "2.4.1",
-          "from": "lodash.keys@>=2.4.1 <2.5.0"
+          "from": "lodash.keys@2.4.1",
+          "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz"
         }
       }
     },
@@ -3764,7 +3781,8 @@
       "dependencies": {
         "lodash.keys": {
           "version": "2.4.1",
-          "from": "lodash.keys@>=2.4.1 <2.5.0"
+          "from": "lodash.keys@2.4.1",
+          "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz"
         }
       }
     },
@@ -3859,7 +3877,8 @@
       "dependencies": {
         "lodash.keys": {
           "version": "2.4.1",
-          "from": "lodash.keys@>=2.4.1 <2.5.0"
+          "from": "lodash.keys@2.4.1",
+          "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz"
         }
       }
     },
@@ -3879,7 +3898,8 @@
         },
         "semver": {
           "version": "4.3.6",
-          "from": "semver@>=4.3.3 <4.4.0"
+          "from": "semver@4.3.6",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
         }
       }
     },
@@ -4081,7 +4101,8 @@
         },
         "isarray": {
           "version": "0.0.1",
-          "from": "isarray@0.0.1"
+          "from": "isarray@0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
         },
         "readable-stream": {
           "version": "1.1.14",
@@ -4904,7 +4925,8 @@
       "dependencies": {
         "isarray": {
           "version": "0.0.1",
-          "from": "isarray@0.0.1"
+          "from": "isarray@0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
         },
         "socket.io-parser": {
           "version": "2.2.2",
@@ -5247,7 +5269,8 @@
       "dependencies": {
         "readable-stream": {
           "version": "2.0.6",
-          "from": "readable-stream@>=2.0.0 <2.1.0"
+          "from": "readable-stream@2.0.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
         },
         "through2": {
           "version": "2.0.1",
@@ -5660,6 +5683,11 @@
       "version": "2.0.1",
       "from": "xml-name-validator@>=2.0.1 <3.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz"
+    },
+    "xmlbuilder": {
+      "version": "8.2.2",
+      "from": "xmlbuilder@8.2.2",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-8.2.2.tgz"
     },
     "xmlhttprequest-ssl": {
       "version": "1.5.1",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "babelify": "7.3.0",
     "browserify": "13.0.1",
     "chai": "3.5.0",
-    "enzyme": "2.3.0",
+    "enzyme": "2.4.1",
     "eslint-plugin-react": "5.2.2",
     "flow-bin": "0.27.0",
     "gulp": "3.9.1",

--- a/src/js/components/Toast.jsx
+++ b/src/js/components/Toast.jsx
@@ -1,9 +1,5 @@
 import React, {Component, PropTypes} from 'react';
-import ReactDOM from 'react-dom';
-import ReactCSSTransitionGroup from 'react-addons-css-transition-group';
 import {Icon} from 'react-material-icons-blue';
-
-const { func, number, string } = PropTypes;
 
 /**
  * Toast displays a small confirmation message with an optional action link and dismiss link.
@@ -14,98 +10,41 @@ const { func, number, string } = PropTypes;
  * action - Optional action link, e.g. "Open"
  * onActionClick - function to invoke when action link is clicked
  * onDismiss - function to invoke when dismiss link is clicked, or Toast auto-dismisses.
- * dismissDelay - Duration in millis before dialog dismisses itself. default is 5000
  */
 export class Toast extends Component {
-    constructor() {
-        super();
-        this.state = {
-            dismissing: false
-        };
-        this._dismissingTimeoutID = 0;
-        this._destroyingTImeoutID = 0;
-    }
-
-    componentDidMount() {
-        // disable the auto-dismiss when delay set explicitly to zero
-        if (this.props.dismissDelay === 0) {
-            return;
-        }
-
-        const delay = this.props.dismissDelay || 5000;
-
-        // automatically dismiss the component after specified delay
-        this._dismissingTimeoutID = setTimeout(() => {
-            this.callDismissListener();
-            this.hideComponent();
-        }, delay);
-    }
-
-    componentWillUnmount() {
-        clearTimeout(this._dismissingTimeoutID);
-        clearTimeout(this._destroyingTImeoutID);
-    }
 
     onActionClick() {
         if (this.props.onActionClick) {
             this.props.onActionClick();
         }
-
-        this.hideComponent();
     }
 
     onDismissClick() {
-        this.callDismissListener();
-        this.hideComponent();
-    }
-
-    callDismissListener() {
         if (this.props.onDismiss) {
             this.props.onDismiss();
         }
     }
 
-    hideComponent() {
-        this.setState({
-            dismissing: true
-        });
-
-        clearTimeout(this._dismissingTimeoutID);
-        this._destroyingTImeoutID = setTimeout(() => this.destroyComponent(), 300);
-    }
-
-    destroyComponent() {
-        const element = ReactDOM.findDOMNode(this);
-        ReactDOM.unmountComponentAtNode(element);
-    }
-
     render() {
         return (
-            <ReactCSSTransitionGroup transitionName="toast" transitionAppear
-                transitionAppearTimeout={300} transitionEnterTimeout={300} transitionLeaveTimeout={300}
-            >
-                { !this.state.dismissing ?
-                <div className="toast">
-                    <span className="text">{this.props.text}</span>
-                    <a className="action" onClick={() => this.onActionClick()}>{this.props.action}</a>
-                    <a className="dismiss" onClick={() => this.onDismissClick()}>
-                      <Icon {...{
-                          size: 18,
-                          icon: 'clear',
-                          style: { fill: "#fff" },
-                      }} />
-                    </a>
-                </div>
-                : null }
-            </ReactCSSTransitionGroup>
+            <div className="toast">
+                <span className="text">{this.props.text}</span>
+                <a className="action" onClick={() => this.onActionClick()}>{this.props.action}</a>
+                <a className="dismiss" onClick={() => this.onDismissClick()}>
+                  <Icon {...{
+                      size: 18,
+                      icon: 'clear',
+                      style: { fill: "#fff" },
+                  }} />
+                </a>
+            </div>
         );
     }
 }
 
 Toast.propTypes = {
-    text: string,
-    action: string,
-    onActionClick: func,
-    onDismiss: func,
-    dismissDelay: number,
+    text: PropTypes.string,
+    action: PropTypes.string,
+    onActionClick: PropTypes.func,
+    onDismiss: PropTypes.func,
 };

--- a/src/js/components/Toaster.jsx
+++ b/src/js/components/Toaster.jsx
@@ -38,6 +38,10 @@ export class Toaster extends Component {
     }
 
     _initialize(props) {
+        if(!props.toasts) {
+            return;
+        }
+
         for (const toast of props.toasts) {
             const dismissDelay = toast.dismissDelay || props.dismissDelay || 5000;
 
@@ -119,4 +123,8 @@ Toaster.propTypes = {
     onActionClick: PropTypes.func,
     onDismiss: PropTypes.func,
     dismissDelay: PropTypes.number,
+};
+
+Toaster.defaultProps = {
+    toasts: [],
 };

--- a/src/js/components/Toaster.jsx
+++ b/src/js/components/Toaster.jsx
@@ -1,0 +1,122 @@
+/**
+ * Created by cmeyers on 8/17/16.
+ */
+import React, { Component, PropTypes } from 'react';
+import TransitionGroup from 'react-addons-css-transition-group';
+
+import { Toast } from './Toast';
+
+/**
+ * Toaster is a container for Toast instances displayed based on supplied 'toasts' prop.
+ *
+ * Supported props:
+ * toasts - array of toast objects
+ * {
+ *     id: unique identifier
+ *     text: string, message text to display
+ *     action: string, text for action link
+ *     onActionClick: function, callback to invoke when action link is clicked
+ *     onDismiss: function, callback to invoke when toast is dismissed (immediately, or after timeout)
+ *     dismissDelay: number, duration in millis after which to auto-dismiss this Toast
+ * }
+ * dismissDelay - number, default duration in millis after which to hide a Toast
+ */
+export class Toaster extends Component {
+
+    constructor() {
+        super();
+
+        this.activeToasts = {};
+    }
+
+    componentWillMount() {
+        this._initialize(this.props);
+    }
+
+    componentWillReceiveProps(nextProps) {
+        this._initialize(nextProps);
+    }
+
+    _initialize(props) {
+        for (const toast of props.toasts) {
+            const dismissDelay = toast.dismissDelay || props.dismissDelay || 5000;
+
+            // if we aren't already tracking the toast, add an auto-dismiss handler and store the timeoutId
+            if (!this.activeToasts[toast.id]) {
+                const timeoutId = setTimeout(() => this._onDismiss(toast), dismissDelay);
+                this.activeToasts[toast.id] = timeoutId;
+            }
+        }
+    }
+
+    _onActionClick(toast) {
+        this._cleanup(toast);
+
+        if (toast.onActionClick) {
+            toast.onActionClick();
+        }
+
+        if (this.props.onActionClick) {
+            this.props.onActionClick(toast);
+        }
+    }
+
+    _onDismiss(toast) {
+        this._cleanup(toast);
+
+        if (toast.onDismiss) {
+            toast.onDismiss();
+        }
+
+        if (this.props.onDismiss) {
+            this.props.onDismiss(toast);
+        }
+    }
+
+    _cleanup(toast) {
+        const timeoutId = this.activeToasts[toast.id];
+
+        if (timeoutId) {
+            clearTimeout(timeoutId);
+            delete this.activeToasts[toast.id];
+        }
+    }
+
+    render() {
+        return (
+            <div className="toaster">
+                <TransitionGroup
+                    transitionName="toast"
+                    transitionAppear
+                    transitionAppearTimeout={300} transitionEnterTimeout={300} transitionLeaveTimeout={300}
+                >
+                    { this.props.toasts.map((toast) => {
+                        if (!toast.id) {
+                            console.warn("toast cannot be added without 'id' property", toast);
+                            return null;
+                        }
+
+                        const key = toast.id;
+
+                        return (
+                            <Toast
+                                key={key}
+                                text={toast.text}
+                                action={toast.action}
+                                onActionClick={() => this._onActionClick(toast)}
+                                onDismiss={() => this._onDismiss(toast)}
+                            />
+                       );
+                    })}
+                </TransitionGroup>
+            </div>
+        );
+    }
+}
+
+Toaster.propTypes = {
+    toasts: PropTypes.array,
+    onActionClick: PropTypes.func,
+    onDismiss: PropTypes.func,
+    dismissDelay: PropTypes.number,
+};

--- a/src/js/components/index.js
+++ b/src/js/components/index.js
@@ -28,6 +28,7 @@ export {EmptyStateIcon} from './EmptyStateIcon';
 export {PipelineGraph} from './PipelineGraph';
 export {FileSize} from './FileSize';
 export {Toast} from './Toast';
+export {Toaster} from './Toaster';
 export {ResultItem} from './ResultItem';
 export {TimeDuration} from './TimeDuration';
 export { Progress } from './Progress';

--- a/src/js/stories/ToasterStories.jsx
+++ b/src/js/stories/ToasterStories.jsx
@@ -1,0 +1,101 @@
+/**
+ * Created by cmeyers on 8/17/16.
+ */
+import React, { Component, PropTypes } from 'react';
+import { storiesOf } from '@kadira/storybook';
+
+import { Toaster } from '../components/Toaster';
+
+class ToasterTester extends Component {
+
+    constructor() {
+        super();
+        this.toasts = [];
+        this.counter = 0;
+    }
+
+    componentWillMount() {
+        if (this.props.toasts) {
+            this.toasts = this.toasts.concat(this.props.toasts);
+        }
+    }
+
+    _addToast() {
+        const id = Math.random() * Math.pow(10,16);
+        const counter = this.counter++;
+
+        this.toasts.push({
+            id: id,
+            text: `Hello World Hello World Hello World Hello World ${counter}`,
+            action: 'Action',
+        });
+        this.forceUpdate();
+    }
+
+    _onActionClick(toast) {
+        const index = this.toasts.indexOf(toast);
+        this.toasts.splice(index, 1);
+        this.forceUpdate();
+    }
+
+    _onDismiss(toast) {
+        const index = this.toasts.indexOf(toast);
+
+        if (index >= 0) {
+            this.toasts.splice(index, 1);
+            this.forceUpdate();
+        }
+    }
+
+    render() {
+        const containerStyle = { position: 'absolute', bottom: 0, minWidth: 400, height: 250 };
+        const toasterStyle = { position: 'absolute', top: 0, bottom: 50, width: 400, backgroundColor: '#eee' };
+        const buttonStyle = { position: 'absolute', bottom: 0 };
+
+        return (
+            <div style={containerStyle}>
+                <div style={toasterStyle}>
+                    <Toaster
+                        toasts={this.toasts}
+                        onActionClick={(toast) => this._onActionClick(toast)}
+                        onDismiss={(toast) => this._onDismiss(toast)}
+                        dismissDelay={this.props.dismissDelay}
+                    />
+                </div>
+
+                <button
+                    onClick={() => this._addToast()}
+                    style={buttonStyle}
+                >
+                    Add Toast
+                </button>
+            </div>
+        );
+    }
+}
+
+ToasterTester.propTypes = {
+    toasts: PropTypes.array,
+    dismissDelay: PropTypes.number,
+};
+
+storiesOf('Toaster', module)
+    .add('default', () => {
+        return (
+            <ToasterTester />
+        );
+    })
+    .add('with 1 toast', () => {
+        const toasts = [
+            {
+                id: Math.random() * Math.pow(10,16),
+                text: 'Hello World',
+                action: 'Toast!',
+                dismissDelay: 10000
+            }
+        ];
+
+        return (
+            <ToasterTester toasts={toasts} />
+        );
+    });

--- a/src/js/stories/index.jsx
+++ b/src/js/stories/index.jsx
@@ -11,6 +11,7 @@ require('./liveStatusIndicatorStories');
 require('./table.jsx');
 require('./timeduration.jsx');
 require('./toast.jsx');
+require('./ToasterStories.jsx');
 require('./resultItemStories.jsx');
 require('./typography.jsx');
 require('./progressBarStories');

--- a/test/js/components/Toaster-spec.jsx
+++ b/test/js/components/Toaster-spec.jsx
@@ -1,0 +1,39 @@
+/**
+ * Created by cmeyers on 8/22/16.
+ */
+import 'babel-polyfill';
+import React from 'react';
+import { assert } from 'chai';
+import { render, shallow } from 'enzyme';
+
+import { Toaster } from '../../../src/js/components';
+
+describe("Toaster", () => {
+
+    it("renders empty container with no data", () => {
+        const wrapper = shallow(<Toaster />);
+
+        assert.equal(
+            wrapper.html(),
+            `<div class="toaster"><span></span></div>`
+        );
+    });
+
+    it("renders a single toast", () => {
+        const _toasts = [
+            { id: 1, text: "Hello World", action: "CLOSE" },
+        ];
+
+        const toaster = render(
+            <Toaster toasts={_toasts} />
+        );
+
+        const toasts = toaster.find('.toast');
+        assert.equal(toasts.length, 1);
+
+        assert.equal(toasts.find('.text').length, 1);
+        assert.equal(toasts.find('.action').length, 1);
+        assert.equal(toasts.find('.dismiss').length, 1);
+    });
+
+});


### PR DESCRIPTION
**Description**
- `Toaster` now receives an array of data objects as props and handles rendering of multiple toasts in a sensible way.
- Next step in separate PR is to add a `ToastService` to `blueocean-core-js` that clients can use to push in new Toasts, and to add `Toaster` to `blueocean-web` so its part of main Blue Ocean UI.
- Unfortunately the use of ReactCssTransitionGroup makes this hard to test w/ shallow renders; hopefully the storybook "counts" (but I know it really doesn't). Feel free to flog me for this and perhaps I can do some deep renders.

**Submitter checklist**
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Instructions for reviewer:
 - You can load up the `Toaster` example in Storybook to see it in action.

**Reviewer checklist**
- [ ] Run the changes and verified the change matches the issue description
- [x] Reviewed the code
- [x] Verified that the appropriate tests have been written or valid explanation given

@reviewbybees 
