### PR TITLE
[git2.9] make script compatible with git 2.9

### DIFF
--- a/site-publish.sh
+++ b/site-publish.sh
@@ -12,10 +12,11 @@ git fetch --depth=1 webpages gh-pages
 
 git add --all
 git commit -m "webpages"
-git merge --no-edit -s ours remotes/webpages/gh-pages
+git merge --no-edit -s ours remotes/webpages/gh-pages --allow-unrelated-histories
 
 git push webpages master:gh-pages
 
 rm -rf .git
 
 popd
+


### PR DESCRIPTION
**Description**

"git merge" used to allow merging two branches that have no common base by default, which led to a brand new history of an existing project created and then get pulled by an unsuspecting maintainer, which allowed an unnecessary parallel history merged into the existing project. The command has been taught not to allow this by default, with an escape hatch "--allow-unrelated-histories" option to be used in a rare event that merges histories of two projects that started their lives independently.

@reviewbybees

