### PR TITLE
Bug/jenkins 38023 expandable path tweak1

### DIFF
--- a/src/js/components/ExpandablePath.jsx
+++ b/src/js/components/ExpandablePath.jsx
@@ -60,7 +60,7 @@ export class ExpandablePath extends Component {
                         return (
                             <li key={index} className={`path-item ${displayClass}`}>
                                 <Icon size={this.props.iconSize} icon="folder" style={ { fill: '#ccc' } }/>
-                                <span className="path-text">{label}</span>
+                                <span className="path-text">{label.trim()}</span>
                                 <span className="separator">&nbsp;/&nbsp;</span>
                             </li>
                         );

--- a/src/js/components/ExpandablePath.jsx
+++ b/src/js/components/ExpandablePath.jsx
@@ -17,6 +17,7 @@ const SHOW_FOLDER_CLASS = 'show-folder';
  *      iconSize: for folder icons, in pixels
  *      path: a forward-slash delimited string of a path, e.g. 'folder1/folder2/pipeline'
  *      hideFirst: set to true to display the first path element as a folder.
+ *      uriDecode: set to true to show uri-decoded form of each path element.
  */
 export class ExpandablePath extends Component {
 
@@ -48,6 +49,8 @@ export class ExpandablePath extends Component {
                         const isSecondLast = (index + 1) === (elements.length - 1);
                         const isLast = (index + 1) === elements.length;
 
+                        const label = this.props.uriDecode ? decodeURIComponent(pathElem) : pathElem;
+
                         let displayClass = SHOW_FOLDER_CLASS;
 
                         if ((isFirst && !this.props.hideFirst) || isSecondLast || isLast) {
@@ -57,7 +60,7 @@ export class ExpandablePath extends Component {
                         return (
                             <li key={index} className={`path-item ${displayClass}`}>
                                 <Icon size={this.props.iconSize} icon="folder" style={ { fill: '#ccc' } }/>
-                                <span className="path-text">{pathElem}</span>
+                                <span className="path-text">{label}</span>
                                 <span className="separator">&nbsp;/&nbsp;</span>
                             </li>
                         );
@@ -73,9 +76,11 @@ ExpandablePath.propTypes = {
     iconSize: PropTypes.number,
     path: PropTypes.string,
     hideFirst: PropTypes.bool,
+    uriDecode: PropTypes.bool,
 };
 
 ExpandablePath.defaultProps = {
     iconSize: 16,
     hideFirst: false,
+    uriDecode: true,
 };

--- a/src/js/stories/ExpandablePathStories.jsx
+++ b/src/js/stories/ExpandablePathStories.jsx
@@ -38,12 +38,26 @@ storiesOf('ExpandablePath', module)
             <ExpandablePath path={path} hideFirst />
         );
     })
-    .add('with link', () => {
+    .add('with uri-encoded parts', () => {
+        const path = 'jenkins / Pipeline%20Jobs / pipeline1';
+        return (
+            <ExpandablePath path={path} />
+        );
+    })
+    .add('style: with link', () => {
         const path = 'Jenkins / folder1 / folder2 / pipeline';
         return (
             <a href="http://jenkins.io" target="_blank">
                 <ExpandablePath path={path} />
             </a>
+        );
+    })
+    .add('style: large', () => {
+        const path = 'Jenkins / folder1 / folder2 / pipeline';
+        return (
+            <div style={ { fontSize: 24 } }>
+                <ExpandablePath path={path} iconSize={28} />
+            </div>
         );
     })
     .add('custom label', () => {
@@ -53,13 +67,5 @@ storiesOf('ExpandablePath', module)
             <a href="http://jenkins.io" target="_blank">
                 <ExpandablePath path={path} />
             </a>
-        );
-    })
-    .add('large', () => {
-        const path = 'Jenkins / folder1 / folder2 / pipeline';
-        return (
-            <div style={ { fontSize: 24 } }>
-                <ExpandablePath path={path} iconSize={28} />
-            </div>
         );
     });

--- a/test/js/components/ExpandablePath-spec.jsx
+++ b/test/js/components/ExpandablePath-spec.jsx
@@ -15,14 +15,14 @@ describe("ExpandablePath", () => {
         assert.isTrue(wrapper.equals(null));
     });
 
-    it("by default, renders two visible labels", () => {
+    it("renders two visible labels", () => {
         const name = 'jenkins / pipeline';
         const wrapper = shallow(<ExpandablePath path={name} />);
 
         assert.equal(wrapper.find('.show-label').length, 2);
     });
 
-    it("by default, renders three labels and two folders", () => {
+    it("renders three labels and two folders", () => {
         const name = 'jenkins / folder1 / folder2 / folder3 / pipeline';
         const wrapper = shallow(<ExpandablePath path={name} />);
 
@@ -30,12 +30,30 @@ describe("ExpandablePath", () => {
         assert.equal(wrapper.find('.show-folder').length, 2);
     });
 
-    it("using hideFirst, renders two labels and three folders", () => {
+    it("using hideFirst=true, renders two labels and three folders", () => {
         const name = 'jenkins / folder1 / folder2 / folder3 / pipeline';
         const wrapper = shallow(<ExpandablePath path={name} hideFirst />);
 
         assert.equal(wrapper.find('.show-label').length, 2);
         assert.equal(wrapper.find('.show-folder').length, 3);
+    });
+
+    it('using uriDecode=true, renders clean path name', () => {
+        const name = 'jenkins / Pipeline%20Jobs / pipeline1';
+        const wrapper = shallow(<ExpandablePath path={name} uriDecode />);
+
+        const pathItems = wrapper.find('.path-item');
+        assert.equal(pathItems.length, 3);
+        assert.equal(pathItems.at(1).find('.path-text').text(), 'Pipeline Jobs');
+    });
+
+    it('using uriDecode=false, renders ugly path name', () => {
+        const name = 'jenkins / Pipeline%20Jobs / pipeline1';
+        const wrapper = shallow(<ExpandablePath path={name} uriDecode={false} />);
+
+        const pathItems = wrapper.find('.path-item');
+        assert.equal(pathItems.length, 3);
+        assert.equal(pathItems.at(1).find('.path-text').text(), 'Pipeline%20Jobs');
     });
 
     describe('replaceLastPathElement', () => {


### PR DESCRIPTION
**Description**
- Small enhancement to component to allow for URI-decoding path elements.
- See [JENKINS-38023](https://issues.jenkins-ci.org/browse/JENKINS-38024).

**Submitter checklist**
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests

**Reviewer checklist**
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

@reviewbybees
