### PR TITLE
[JENKINS-39761] Fix to FileSize

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jenkins-cd/design-language",
   "jdlName": "jenkins-design-language",
-  "version": "0.0.91-bluerun-perfomance-beta1",
+  "version": "0.0.92-unpublished",
   "description": "Styles, assets, and React classes for Jenkins Design Language",
   "main": "dist/js/components/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jenkins-cd/design-language",
   "jdlName": "jenkins-design-language",
-  "version": "0.0.91-unpublished",
+  "version": "0.0.91-bluerun-perfomance-beta1",
   "description": "Styles, assets, and React classes for Jenkins Design Language",
   "main": "dist/js/components/index.js",
   "scripts": {

--- a/src/js/components/FileSize.jsx
+++ b/src/js/components/FileSize.jsx
@@ -20,7 +20,9 @@ export class FileSize extends Component {
             bytes = parseInt(bytes);
         }
 
-        if (!isNaN(bytes)) {
+        if (bytes === 0) {
+             output = `0 ${units[0]}`;
+        } else if (!isNaN(bytes)) {
             // calculate the unit (e.g. 'MB') to display
             // but ensure it doesn't go over the max we support
             let power = Math.floor(log10(Math.abs(bytes)) / log10(1024));

--- a/src/js/stories/filesize.jsx
+++ b/src/js/stories/filesize.jsx
@@ -3,6 +3,7 @@ import { storiesOf } from '@kadira/storybook';
 import { FileSize } from '../components/FileSize';
 
 storiesOf('FileSize', module)
+    .add('0 bytes', scenario0)
     .add('5 bytes', scenario1)
     .add('1 kilobyte', scenario2)
     .add('5.5 kilobyte', scenario3)
@@ -11,6 +12,12 @@ storiesOf('FileSize', module)
     .add('bogus', scenario6)
     .add('large', scenario7)
     .add('negative', scenario8);
+
+function scenario0() {
+    return (
+        <FileSize bytes={0} />
+    );
+}
 
 function scenario1() {
     return (

--- a/test/js/components/FileSize-spec.jsx
+++ b/test/js/components/FileSize-spec.jsx
@@ -22,6 +22,13 @@ describe("FileSize", () => {
         ));
     });
 
+    it("renders 0 bytes", () => {
+        const wrapper = shallow(<FileSize bytes={0} />);
+
+        assert.isTrue(wrapper.is('span'));
+        assert.equal(wrapper.text(), '0 bytes');
+    });
+
     it("renders 4 bytes", () => {
         const wrapper = shallow(<FileSize bytes={4} />);
 


### PR DESCRIPTION
**Description**

Display '0 bytes' instead of 'NaN is not a number' when filesize is 0.

- See [JENKINS-39761](https://issues.jenkins-ci.org/browse/JENKINS-39761).

**Submitter checklist**
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests

**Reviewer checklist**
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

@reviewbybees
