### PR TITLE
[JENKINS-35768] support arbitrary content in Table headers

### DIFF
--- a/src/js/components/Table.jsx
+++ b/src/js/components/Table.jsx
@@ -64,11 +64,15 @@ export class Table extends Component {
         const divider = headers && headers.length && !disableHeaderDivider ?
             <TableDivider numCols={headers.length}/> : undefined;
 
-        const headerRowCells = headers && headers.map((column) => (
+        const headerRowCells = headers && headers.map((column) => {
+            const content = !column.content ? getLabel(column) : column.content;
+
+            return (
                 <th key={getKey(column)} className={getClass(column)}>
-                    {getLabel(column)}
+                    {content}
                 </th>
-            ));
+            );
+        });
 
         const tableHeader = headers && (
                 <thead>

--- a/src/js/stories/TableStories.jsx
+++ b/src/js/stories/TableStories.jsx
@@ -17,6 +17,7 @@ storiesOf('Table', module)
     .add('No Divider', scenario1NoDivider)
     .add('No Default Padding', scenario1NoPadding)
     .add('Long Text', longText)
+    .add('Custom Header', customHeader)
     .add('Table class', scenario2)
     .add('Header class', scenario3)
     .add('Fluid columns', scenario4)
@@ -139,6 +140,24 @@ function longText() {
                 {tbody}
             </Table>
         </div>
+    );
+}
+
+function customHeader() {
+    const customHeaders = detailedHeaders.slice();
+    customHeaders[4] = {
+        label: 'Blood Type',
+        content: (
+            <div>
+                Blood Type: <input type="text" style={{width: 50}} />
+            </div>
+        )
+    };
+
+    return (
+        <Table headers={customHeaders}>
+            { detailedData.map(renderRow) }
+        </Table>
     );
 }
 


### PR DESCRIPTION
**Description**
- The JIRA ticket linked below requires arbitrary React / HTML content inside of a table header cell. This was the least invasive change to accomplish it.
- See [JENKINS-35768](https://issues.jenkins-ci.org/browse/JENKINS-35768).

**Submitter checklist**
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests

**Reviewer checklist**
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

@reviewbybees
