### PR TITLE
[FIX JENKINS-40932] combine css

### DIFF
--- a/.storybook/head.html
+++ b/.storybook/head.html
@@ -2,13 +2,6 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 
-<!-- Reset -->
-<link href="./css/normalize.css" rel="stylesheet">
-
-<!-- Icons -->
-<link href="./css/latofonts.css" rel="stylesheet">
-<link href="./octicons/octicons.css" rel="stylesheet">
-
 <!-- Jenkins theme -->
 <link href="./css/jenkins-design-language.css" rel="stylesheet">
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -43,15 +43,7 @@ const config = {
             dest: "dist/assets/"
         },
         octicons: {
-            sources: "node_modules/octicons/build/font/octicons.{eot,woff,woff2,ttf,svg,css}",
-            dest: "dist/assets/octicons/"
-        },
-        normalize: {
-            sources: "node_modules/normalize.css/normalize.css",
-            dest: "dist/assets/css/"
-        },
-        fontsCSS: {
-            sources: "fonts/*.css",
+            sources: "node_modules/octicons/build/font/octicons.{eot,woff,woff2,ttf,svg}",
             dest: "dist/assets/css/"
         },
         fonts: {
@@ -173,7 +165,7 @@ gulp.task("svgmin", () =>
 
 // Copy things
 
-gulp.task("copy", ["copy-icons", "copy-octicons", "copy-normalize", "copy-fontsCSS", "copy-fonts",
+gulp.task("copy", ["copy-icons", "copy-octicons", "copy-fonts",
     "copy-componentDocFiles", "copy-licenses-octicons", "copy-licenses-ofl"]);
 
 gulp.task("copy-icons", () =>
@@ -183,14 +175,6 @@ gulp.task("copy-icons", () =>
 gulp.task("copy-octicons", () =>
     gulp.src(config.copy.octicons.sources)
         .pipe(copy(config.copy.octicons.dest, {prefix: 4})));
-
-gulp.task("copy-normalize", () =>
-    gulp.src(config.copy.normalize.sources)
-        .pipe(copy(config.copy.normalize.dest, {prefix: 2})));
-
-gulp.task("copy-fontsCSS", () =>
-    gulp.src(config.copy.fontsCSS.sources)
-        .pipe(copy(config.copy.fontsCSS.dest, {prefix: 1})));
 
 gulp.task("copy-fonts", () =>
     gulp.src(config.copy.fonts.sources)

--- a/less/theme.less
+++ b/less/theme.less
@@ -5,6 +5,13 @@
 */
 
 //
+// Import 3rd part CSS before JDL LESS modules.
+//
+@import (inline) "../node_modules/normalize.css/normalize.css";
+@import (inline) "../fonts/latofonts.css";
+@import (inline) "../node_modules/octicons/build/font/octicons.css";
+
+//
 // Load core variables and mixins
 // --------------------------------------------------
 @import "variables";

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jenkins-cd/design-language",
   "jdlName": "jenkins-design-language",
-  "version": "0.0.100-tfbeta1",
+  "version": "0.0.100",
   "description": "Styles, assets, and React classes for Jenkins Design Language",
   "main": "dist/js/components/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jenkins-cd/design-language",
   "jdlName": "jenkins-design-language",
-  "version": "0.0.100",
+  "version": "0.0.101-unpublished",
   "description": "Styles, assets, and React classes for Jenkins Design Language",
   "main": "dist/js/components/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jenkins-cd/design-language",
   "jdlName": "jenkins-design-language",
-  "version": "0.0.100-unpublished",
+  "version": "0.0.100-tfbeta1",
   "description": "Styles, assets, and React classes for Jenkins Design Language",
   "main": "dist/js/components/index.js",
   "scripts": {


### PR DESCRIPTION
## Description

Inline `normalize.css`, `latofonts.css` and `octicons.css` into the JDL's css file, eliminating 3 css resource requests.

- See [JENKINS-40932](https://issues.jenkins-ci.org/browse/JENKINS-40932).
- See https://github.com/jenkinsci/blueocean-plugin/pull/694

## Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests. Not applicable.

## Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

@reviewbybees
