### PR TITLE
[FIX JENKINS-39857_Display_steps_durations_in_Blue_Ocean]

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jenkins-cd/design-language",
   "jdlName": "jenkins-design-language",
-  "version": "0.0.105-unpublishedTime",
+  "version": "0.0.105-TimePrecise",
   "description": "Styles, assets, and React classes for Jenkins Design Language",
   "main": "dist/js/components/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jenkins-cd/design-language",
   "jdlName": "jenkins-design-language",
-  "version": "0.0.105-TimePrecise",
+  "version": "0.0.106-unpublished",
   "description": "Styles, assets, and React classes for Jenkins Design Language",
   "main": "dist/js/components/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jenkins-cd/design-language",
   "jdlName": "jenkins-design-language",
-  "version": "0.0.105-unpublished",
+  "version": "0.0.105-unpublishedTime",
   "description": "Styles, assets, and React classes for Jenkins Design Language",
   "main": "dist/js/components/index.js",
   "scripts": {

--- a/src/js/components/ResultItem.jsx
+++ b/src/js/components/ResultItem.jsx
@@ -17,7 +17,7 @@ type State = {
 type Props = {
     result: Result,
     label: String,
-    extraInfo: ?String,
+    extraInfo: ?String | Object,
     data: ?any,
     onExpand: (data: ?any, event: ?Event) => void,
     onCollapse: (data: ?any, event: ?Event) => void,

--- a/src/js/components/ResultItem.jsx
+++ b/src/js/components/ResultItem.jsx
@@ -124,7 +124,7 @@ export class ResultItem extends Component {
 ResultItem.propTypes = {
     result: PropTypes.oneOf(Object.keys(StatusIndicator.validResultValues)),
     label: PropTypes.string,
-    extraInfo: PropTypes.string,
+    extraInfo: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
     data: PropTypes.any, // Whatever you want, will be sent back to listeners
     onExpand: PropTypes.func, // f(data:*, originalEvent:?event)
     onCollapse: PropTypes.func, // f(data:*, originalEvent:?event)

--- a/src/js/components/TimeDuration.jsx
+++ b/src/js/components/TimeDuration.jsx
@@ -11,6 +11,7 @@ type Props = {
      updatePeriod: number,
      hint?: string,
      liveUpdate: bool,
+     displayFormat: ?string,
      liveFormat: ?string,
      hintFormat: ?string,
      locale: ?string,
@@ -46,7 +47,7 @@ export class TimeDuration extends Component {
         const {updatePeriod = 30000} = this.props;
         this.timerPeriodMillis = typeof updatePeriod !== 'number' || isNaN(updatePeriod) ? 30000 : updatePeriod;
         this.clearIntervalId = 0;
-        
+
     }
 
     componentWillMount() {

--- a/src/js/components/TimeDuration.jsx
+++ b/src/js/components/TimeDuration.jsx
@@ -99,12 +99,14 @@ export class TimeDuration extends Component {
                 locale = 'en',
                 liveFormat = 'm[ minutes] s[ seconds]',
                 hintFormat = 'M [mos], d [days], h[h], m[m], s[s]',
+                displayFormat,
             } = this.props;
             moment.locale(locale);
             // in case we are in live update we are interested in seconds
             const duration = this.props.liveUpdate ?
                 moment.duration(millis).format(liveFormat)
-                    : moment.duration(millis).humanize();
+                    : displayFormat ?
+                        moment.duration(millis).format(displayFormat) : moment.duration(millis).humanize();
 
             const hint = this.props.hint ?
                 this.props.hint :
@@ -125,6 +127,7 @@ TimeDuration.propTypes = {
     hint: PropTypes.string,
     liveUpdate: PropTypes.bool,
     locale: PropTypes.string,
+    displayFormat: PropTypes.string,
     liveFormat: PropTypes.string,
     hintFormat: PropTypes.string,
 };

--- a/src/js/components/TimeDuration.jsx
+++ b/src/js/components/TimeDuration.jsx
@@ -98,20 +98,17 @@ export class TimeDuration extends Component {
         if (!isNaN(millis)) {
             const {
                 locale = 'en',
+                displayFormat = 'M[ month] d[ days] h[ hours] m[ minutes] s[ seconds]',
                 liveFormat = 'm[ minutes] s[ seconds]',
                 hintFormat = 'M [mos], d [days], h[h], m[m], s[s]',
-                displayFormat,
             } = this.props;
             moment.locale(locale);
             // in case we are in live update we are interested in seconds
             const duration = this.props.liveUpdate ?
-                moment.duration(millis).format(liveFormat)
-                    : displayFormat ?
-                        moment.duration(millis).format(displayFormat) : moment.duration(millis).humanize();
+                moment.duration(millis).format(liveFormat) : moment.duration(millis).format(displayFormat);
 
             const hint = this.props.hint ?
-                this.props.hint :
-                moment.duration(millis).format(hintFormat);
+                this.props.hint : moment.duration(millis).format(hintFormat);
 
             return (
                 <span title={hint}>{duration}</span>

--- a/src/js/stories/resultItemStories.jsx
+++ b/src/js/stories/resultItemStories.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { storiesOf } from '@kadira/storybook';
 import { ResultItem } from '../components';
+import { TimeDuration } from '../components/TimeDuration';
 
 import lipsum from './lipsum';
 
@@ -35,10 +36,39 @@ function onCollapse(data) {
     console.log("Collapsing",data);
 }
 
+function standardDe() {
+    return (
+        <TimeDuration
+            millis={5000000}
+            locale="de"
+            displayFormat="M [mos], d [Tage], h[Std.], m[m], s[s]"
+            hintFormat="M [Monate], d [Tage], h[Std.], m[m], s[s]"
+            liveFormat="m[ Minuten] s[ Sekunden]"
+        />
+    );
+}
+
+function liveUpdateDe() {
+    return (
+        <TimeDuration
+            liveUpdate
+            updatePeriod={3000}
+            millis={50000}
+            locale="de"
+            hintFormat="M [mos], d [Tage], h[Std.], m[m], s[s]"
+            liveFormat="m[ Minuten] s[ Sekunden]"
+        />
+    );
+}
+
 function basicStory() {
 
     return (
         <div style={wrapperStyle}>
+            <ResultItem result="success" label="Successful Step custom object" extraInfo={standardDe()} onExpand={onExpand}
+                        onCollapse={onCollapse} data="bravo">{moLipsum()}</ResultItem>
+            <ResultItem result="success" label="Successful Step custom objectLive" extraInfo={liveUpdateDe()} onExpand={onExpand}
+                        onCollapse={onCollapse} data="bravo">{moLipsum()}</ResultItem>
             <ResultItem result="success" label="Successful Step" extraInfo="11 sec" onExpand={onExpand}
                         onCollapse={onCollapse} data="bravo">{moLipsum()}</ResultItem>
             <ResultItem result="failure" label="Failed Step" extraInfo="29 sec" onExpand={onExpand}
@@ -55,7 +85,7 @@ function basicStory() {
                         onCollapse={onCollapse} data="foxtrot" expanded="true">{moLipsum()}</ResultItem>
 
             <h2>Separator</h2>
-            
+
             <ResultItem result="running" label="Running Step, with taller child" extraInfo="a few seconds"
                         onExpand={onExpand} onCollapse={onCollapse} data="foxtrot">
                 <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Consequuntur deserunt dicta impedit nam
@@ -67,9 +97,9 @@ function basicStory() {
                 <p>&nbsp;</p><p>&nbsp;</p><p>&nbsp;</p>
                 <p>Eius enim magnam obcaecati perferendis quam?</p>
             </ResultItem>
-            
+
             <h2>Separator</h2>
-            
+
             <ResultItem result="unstable" label="Unstable Step" extraInfo="55 sec" onExpand={onExpand}
                         onCollapse={onCollapse} data="golf">{moLipsum()}</ResultItem>
             <ResultItem result="not_built" label="Not Built Step - no details"/>

--- a/test/js/components/TimeDuration-spec.jsx
+++ b/test/js/components/TimeDuration-spec.jsx
@@ -23,10 +23,9 @@ describe("TimeDuration", () => {
     });
 
     it("renders 'a few seconds' with 1ms", () => {
-        const wrapper = shallow(<TimeDuration millis={1} />);
-
+        const wrapper = shallow(<TimeDuration millis={2000} />);
         assert.isTrue(wrapper.is('span'));
-        assert.equal(wrapper.text(), 'a few seconds');
+        assert.equal(wrapper.text(), '2 seconds');
     });
 
     it("renders 'a few seconds' with 1ms as string", () => {
@@ -41,7 +40,7 @@ describe("TimeDuration", () => {
         const wrapper = shallow(<TimeDuration millis={1000*60*60*3.25} />);
 
         assert.isTrue(wrapper.is('span'));
-        assert.equal(wrapper.text(), '3 hours');
+        assert.equal(wrapper.text(), '3 hours 15 minutes 0 seconds');
     });
 
     it("renders a tooltip of '5m, 5s' when supplied value", () => {


### PR DESCRIPTION
… not use humanize() format but a custom one

**Description**
- See [JENKINS-39857](https://issues.jenkins-ci.org/browse/JENKINS-39857) and https://issues.jenkins-ci.org/browse/JENKINS-41282.

Allow that ResultItem to accept an object as well (not only a string as before). Allow timeDuration to not use humanize() format but a custom one.

**Submitter checklist**
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests

**Reviewer checklist**
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

@reviewbybees
