### PR TITLE
[JENKINS-40670] Fix pause icon

### DIFF
--- a/src/js/components/status/SvgStatus.jsx
+++ b/src/js/components/status/SvgStatus.jsx
@@ -40,11 +40,12 @@ export function getGlyphFor(result:Result) {
                 </g>
             );
         case "paused":
-            // "!"
+            // "||"
+            // 8px 9.3px
             return (
-                <g className="result-status-glyph" transform="scale(1.4)">
-                    <polygon points="-3,-4 -3,3 -3,3 -1,3 -1,-4"/>
-                    <polygon points="3,-4 1,-4 1,-4 1,3 3,3"/>
+                <g className="result-status-glyph">
+                    <polygon points="-4,-4.65 -4,4.65 -4,4.65 -1.5,4.65 -1.5,-4.65"/>
+                    <polygon points="4,-4.65 1.5,-4.65 1.5,-4.65 1.5,4.65 4,4.65"/>
                 </g>
             );
         case "unstable":


### PR DESCRIPTION
**Description**

Pause icon's image now is 8px wide, 9.3px high as per zeplin. However I couldn't figure out width of the pause lines, so i made them 2.5px with the gap 3px
- See [JENKINS-40670](https://issues.jenkins-ci.org/browse/JENKINS-40670).

**Submitter checklist**
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests

**Reviewer checklist**
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

@reviewbybees
