### PR TITLE
JENKINS-41554 Navigation disappears if the page content is longer than the window height

### DIFF
--- a/less/components/header.less
+++ b/less/components/header.less
@@ -9,6 +9,7 @@
 //--------------------------------------
 
 .BasicHeader {
+    flex-shrink: 0;
     display: flex;
     flex-direction: column;
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jenkins-cd/design-language",
   "jdlName": "jenkins-design-language",
-  "version": "0.0.108-unpublished",
+  "version": "0.0.108-unpublished-jm-a",
   "description": "Styles, assets, and React classes for Jenkins Design Language",
   "main": "dist/js/components/index.js",
   "scripts": {


### PR DESCRIPTION
Fix header going missing when page contents long

**Description**
- See [JENKINS-41554](https://issues.jenkins-ci.org/browse/JENKINS-41554).

**Submitter checklist**
- [X] Link to JIRA ticket in description, if appropriate.
- [X] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests

**Reviewer checklist**
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

@reviewbybees
