### PR TITLE
[FIX-JENKINS-40929_Developer_can_see_durations_when_hovering_on_indicator…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jenkins-cd/design-language",
   "jdlName": "jenkins-design-language",
-  "version": "0.0.109-unpublished",
+  "version": "0.0.109-unpublishedDuration1",
   "description": "Styles, assets, and React classes for Jenkins Design Language",
   "main": "dist/js/components/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jenkins-cd/design-language",
   "jdlName": "jenkins-design-language",
-  "version": "0.0.111-unpublishedDuration",
+  "version": "0.0.112",
   "description": "Styles, assets, and React classes for Jenkins Design Language",
   "main": "dist/js/components/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jenkins-cd/design-language",
   "jdlName": "jenkins-design-language",
-  "version": "0.0.109-unpublishedDuration1",
+  "version": "0.0.111-unpublishedDuration",
   "description": "Styles, assets, and React classes for Jenkins Design Language",
   "main": "dist/js/components/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jenkins-cd/design-language",
   "jdlName": "jenkins-design-language",
-  "version": "0.0.112",
+  "version": "0.0.113-unpublished",
   "description": "Styles, assets, and React classes for Jenkins Design Language",
   "main": "dist/js/components/index.js",
   "scripts": {

--- a/src/js/components/PipelineGraph.jsx
+++ b/src/js/components/PipelineGraph.jsx
@@ -353,7 +353,6 @@ export class PipelineGraph extends Component {
 
         const nodeIsSelected = this.stageIsSelected(node.stage);
         const { nodeRadius, connectorStrokeWidth } = this.state.layout;
-
         // Use a bigger radius for invisible click/touch target
         const mouseTargetRadius = nodeRadius + (2 * connectorStrokeWidth);
 
@@ -362,7 +361,10 @@ export class PipelineGraph extends Component {
 
         const completePercent = node.completePercent || 0;
         const groupChildren = [getGroupForResult(resultClean, completePercent, nodeRadius)];
-
+        const { title } = node.stage;
+        if (title) {
+          groupChildren.push(<title>{ title }</title>);
+        }
         // Add an invisible click/touch target, coz the nodes are small and (more importantly)
         // many are hollow.
         groupChildren.push(

--- a/src/js/components/PipelineGraph.jsx
+++ b/src/js/components/PipelineGraph.jsx
@@ -21,6 +21,7 @@ export const defaultLayout = {
 
 type StageInfo = {
     name: string,
+    title: string,
     state: Result,
     completePercent: number,
     id: number,
@@ -368,7 +369,7 @@ export class PipelineGraph extends Component {
         // Add an invisible click/touch target, coz the nodes are small and (more importantly)
         // many are hollow.
         groupChildren.push(
-            <circle r={mouseTargetRadius}   
+            <circle r={mouseTargetRadius}
                     cursor="pointer"
                     className="pipeline-node-hittarget"
                     fillOpacity="0"


### PR DESCRIPTION
…s] Allow to add a tooltip title to the nodes in the pipeline graph

**Description**
- See [JENKINS-40929](https://issues.jenkins-ci.org/browse/JENKINS-40929).

see as well https://github.com/jenkinsci/blueocean-plugin/pull/779

**Submitter checklist**
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests

**Reviewer checklist**
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

@reviewbybees
