### PR TITLE
Hotfix/text input icon tweaks

### DIFF
--- a/less/components/text-input.less
+++ b/less/components/text-input.less
@@ -90,7 +90,7 @@ input[type="text"] {
 }
 
 .TextInput-medium {
-    .icon-rules(24px, 6px, 10px);
+    .icon-rules(24px, 4px, 10px);
 
     .TextInput-control {
         padding: 6px 10px;
@@ -98,7 +98,7 @@ input[type="text"] {
 }
 
 .TextInput-large {
-    .icon-rules(28px, 8px, 12px);
+    .icon-rules(28px, 6px, 12px);
 
     .TextInput-control {
         padding: 8px 12px;

--- a/less/components/text-input.less
+++ b/less/components/text-input.less
@@ -7,9 +7,7 @@ input[type="text"] {
 
 .TextInput, .PasswordInput {
     .TextInput-medium;
-    display: inline-flex;
-    flex-flow: row nowrap;
-    align-items: center;
+    display: inline-block;
     position: relative;
     background-color: #fff;
 
@@ -31,47 +29,52 @@ input[type="text"] {
     }
 
     .TextInput-icon {
+        position: absolute;
+        top: 50%;
         fill: #999;
         cursor: default;
     }
 }
 
 
-.icon-rules(@icon-size, @icon-padding) {
-    &.u-icon-left {
-        margin-left: @icon-padding;
+.icon-rules(@icon-size, @icon-padding, @input-padding) {
+    .TextInput-icon {
+        width: @icon-size;
+        height: @icon-size;
+        margin-top: -(@icon-size / 2);
 
+        .svg-icon {
+            width: @icon-size;
+            height: @icon-size;
+        }
+    }
+
+    &.u-icon-left {
         .TextInput-icon.u-icon-left {
-            margin-right: -(@icon-size + @icon-padding);
+            left: @icon-padding;
         }
 
         .TextInput-control {
             padding-left: @icon-size + @icon-padding;
-            margin-right: -(@icon-size - @icon-padding);
+            margin-right: -2 * @input-padding;
         }
     }
 
     &.u-icon-right {
         .TextInput-icon.u-icon-right {
-            margin-left: -(@icon-size + @icon-padding);
-            margin-right: -2 * @icon-padding;
+            right: @icon-padding;
         }
 
         .TextInput-control {
             padding-right: @icon-size + @icon-padding;
+            margin-right: -2 * @input-padding;
         }
     }
 
     &.u-icon-left.u-icon-right {
-        .TextInput-icon.u-icon-right {
-            margin-left: -2 * @icon-padding;
-            margin-right: -(@icon-size + @icon-padding);
+        .TextInput-control {
+            margin-right: 2 * (-2 * @input-padding);
         }
-    }
-
-    .TextInput-icon, .TextInput-icon .svg-icon {
-        width: @icon-size;
-        height: @icon-size;
     }
 }
 
@@ -79,8 +82,7 @@ input[type="text"] {
 // sizing
 
 .TextInput-small {
-    min-width: 175px;
-    .icon-rules(20px, 4px);
+    .icon-rules(20px, 4px, 8px);
 
     .TextInput-control {
         padding: 5px 8px;
@@ -88,8 +90,7 @@ input[type="text"] {
 }
 
 .TextInput-medium {
-    min-width: 200px;
-    .icon-rules(24px, 4px);
+    .icon-rules(24px, 6px, 10px);
 
     .TextInput-control {
         padding: 6px 10px;
@@ -97,8 +98,7 @@ input[type="text"] {
 }
 
 .TextInput-large {
-    min-width: 235px;
-    .icon-rules(28px, 8px);
+    .icon-rules(28px, 8px, 12px);
 
     .TextInput-control {
         padding: 8px 12px;

--- a/less/components/text-input.less
+++ b/less/components/text-input.less
@@ -56,7 +56,7 @@ input[type="text"] {
 
         .TextInput-control {
             padding-left: @icon-size + @icon-padding;
-            margin-right: -2 * @input-padding;
+            margin-right: -(@icon-size + @icon-padding) + @input-padding;
         }
     }
 
@@ -67,13 +67,13 @@ input[type="text"] {
 
         .TextInput-control {
             padding-right: @icon-size + @icon-padding;
-            margin-right: -2 * @input-padding;
+            margin-right: -(@icon-size + @icon-padding) + @input-padding;
         }
     }
 
     &.u-icon-left.u-icon-right {
         .TextInput-control {
-            margin-right: 2 * (-2 * @input-padding);
+            margin-right: 2 * (-(@icon-size + @icon-padding) + @input-padding);
         }
     }
 }


### PR DESCRIPTION
**Description**
- Icon layout had some spacing inconsistencies that were masked by setting a min-width, and min-width was problematic for some views in the editor. instead use absolute positioning which is simpler and requires far fewer compensating margin "hacks". The downside is that we don't get default vertical centering of icons from flexbox, but it doesn't really matter since we are setting icon sizes explicitly anyways.

**Submitter checklist**
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests

**Reviewer checklist**
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

@reviewbybees
