### PR TITLE
Toast styles for JENKINS-41642

### DIFF
--- a/less/components/toast.less
+++ b/less/components/toast.less
@@ -29,6 +29,16 @@
     /* TODO: get proper values from updated sketch file */
     .box-shadow(1px 2px 2px rgba(0, 0, 0, .5));
 
+    &.success, &.error {
+        border-left: 5px solid;
+    }
+    &.success {
+        border-left-color: @brand-success-lite;
+    }
+    &.error {
+        border-left-color: @brand-danger-lite;
+    }
+
     .text, .action, .dismiss {
         align-self: center;
     }

--- a/less/components/toast.less
+++ b/less/components/toast.less
@@ -39,6 +39,10 @@
         border-left-color: @brand-danger-lite;
     }
 
+    .caption {
+        margin-bottom: 10px;
+    }
+
     .text, .action, .dismiss {
         align-self: center;
     }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jenkins-cd/design-language",
   "jdlName": "jenkins-design-language",
-  "version": "0.0.122-tf-JENKINS-41642-2",
+  "version": "0.0.122-tf-JENKINS-41642-3",
   "description": "Styles, assets, and React classes for Jenkins Design Language",
   "main": "dist/js/components/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jenkins-cd/design-language",
   "jdlName": "jenkins-design-language",
-  "version": "0.0.122-tf-JENKINS-41642-3",
+  "version": "0.0.122",
   "description": "Styles, assets, and React classes for Jenkins Design Language",
   "main": "dist/js/components/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jenkins-cd/design-language",
   "jdlName": "jenkins-design-language",
-  "version": "0.0.122-unpublished",
+  "version": "0.0.122-tf-JENKINS-41642-1",
   "description": "Styles, assets, and React classes for Jenkins Design Language",
   "main": "dist/js/components/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jenkins-cd/design-language",
   "jdlName": "jenkins-design-language",
-  "version": "0.0.122-tf-JENKINS-41642-1",
+  "version": "0.0.122-tf-JENKINS-41642-2",
   "description": "Styles, assets, and React classes for Jenkins Design Language",
   "main": "dist/js/components/index.js",
   "scripts": {

--- a/src/js/components/Toast.jsx
+++ b/src/js/components/Toast.jsx
@@ -29,7 +29,10 @@ export class Toast extends Component {
         const toastStyle = (this.props.style || 'default');
         return (
             <div className={`toast ${toastStyle}`}>
-                <span className="text">{this.props.text}</span>
+                <span className="text">
+                    <Caption text={this.props.caption}/>
+                    {this.props.text}
+                </span>
                 <a className="action" onClick={() => this.onActionClick()}>{this.props.action}</a>
                 <a className="dismiss" onClick={() => this.onDismissClick()}>
                   <Icon {...{
@@ -44,9 +47,20 @@ export class Toast extends Component {
 }
 
 Toast.propTypes = {
+    caption: PropTypes.string,
     text: PropTypes.string,
     style: PropTypes.string,
     action: PropTypes.string,
     onActionClick: PropTypes.func,
     onDismiss: PropTypes.func,
+};
+
+const Caption = ({ text }) => {
+    if (!text) {
+        return null;
+    }
+    return (<h4 className="caption">{text}</h4>);
+};
+Caption.propTypes = {
+    text: PropTypes.string,
 };

--- a/src/js/components/Toast.jsx
+++ b/src/js/components/Toast.jsx
@@ -26,8 +26,9 @@ export class Toast extends Component {
     }
 
     render() {
+        const toastStyle = (this.props.style || 'default');
         return (
-            <div className="toast">
+            <div className={`toast ${toastStyle}`}>
                 <span className="text">{this.props.text}</span>
                 <a className="action" onClick={() => this.onActionClick()}>{this.props.action}</a>
                 <a className="dismiss" onClick={() => this.onDismissClick()}>
@@ -44,6 +45,7 @@ export class Toast extends Component {
 
 Toast.propTypes = {
     text: PropTypes.string,
+    style: PropTypes.string,
     action: PropTypes.string,
     onActionClick: PropTypes.func,
     onDismiss: PropTypes.func,

--- a/src/js/components/Toaster.jsx
+++ b/src/js/components/Toaster.jsx
@@ -106,7 +106,9 @@ export class Toaster extends Component {
                         return (
                             <Toast
                                 key={key}
+                                caption={toast.caption}
                                 text={toast.text}
+                                style={toast.style}
                                 action={toast.action}
                                 onActionClick={() => this._onActionClick(toast)}
                                 onDismiss={() => this._onDismiss(toast)}

--- a/src/js/stories/ToasterStories.jsx
+++ b/src/js/stories/ToasterStories.jsx
@@ -98,4 +98,19 @@ storiesOf('Toaster', module)
         return (
             <ToasterTester toasts={toasts} />
         );
-    });
+    })
+    .add('with caption and error', () => {
+        const toasts = [
+            {
+                id: Math.random() * Math.pow(10,16),
+                style: 'error',
+                caption: 'Favorites Error',
+                text: 'Failed to register favorite'
+            }
+        ];
+
+        return (
+            <ToasterTester toasts={toasts} />
+        );
+    })
+;

--- a/src/js/stories/toast.jsx
+++ b/src/js/stories/toast.jsx
@@ -8,7 +8,9 @@ storiesOf('Toast', module)
     .add('no action', scenario3)
     .add('delay of 30s', scenario4)
     .add('handlers', scenario5)
-    .add('within layout', scenario6);
+    .add('within layout', scenario6)
+    .add('success', scenario7)
+    .add('error', scenario8);
 
 function scenario1() {
     return (
@@ -55,5 +57,19 @@ function scenario6() {
             <Toast text="Run Started" action="Open" />
             <span>Element B</span>
         </div>
+    );
+}
+
+function scenario7() {
+    return (
+        <Toast text="Cool, that worked nicely" style="success" action="Open" dismissDelay={0}
+               onActionClick={action('action')} onDismiss={action('dismiss')} />
+    );
+}
+
+function scenario8() {
+    return (
+        <Toast text="There was an error !!" style="error" action="Open" dismissDelay={0}
+               onActionClick={action('action')} onDismiss={action('dismiss')} />
     );
 }

--- a/src/js/stories/toast.jsx
+++ b/src/js/stories/toast.jsx
@@ -10,7 +10,8 @@ storiesOf('Toast', module)
     .add('handlers', scenario5)
     .add('within layout', scenario6)
     .add('success', scenario7)
-    .add('error', scenario8);
+    .add('error', scenario8)
+    .add('error with caption', scenario9);
 
 function scenario1() {
     return (
@@ -62,14 +63,18 @@ function scenario6() {
 
 function scenario7() {
     return (
-        <Toast text="Cool, that worked nicely" style="success" action="Open" dismissDelay={0}
-               onActionClick={action('action')} onDismiss={action('dismiss')} />
+        <Toast text="Cool, that worked nicely" style="success" />
     );
 }
 
 function scenario8() {
     return (
-        <Toast text="There was an error !!" style="error" action="Open" dismissDelay={0}
-               onActionClick={action('action')} onDismiss={action('dismiss')} />
+        <Toast text="There was an error !!" style="error" />
+    );
+}
+
+function scenario9() {
+    return (
+        <Toast caption="Favoriting Error" text="no default branch to favorite" style="error" />
     );
 }


### PR DESCRIPTION
**Description**

Added an optional `style` param to the `Toast` component, with values of `default`, `success` and `error`. Also added a trial `caption` param (also optional).

<img width="377" alt="screenshot 2017-03-02 17 56 38" src="https://cloud.githubusercontent.com/assets/429311/23520224/f678733c-ff71-11e6-8189-5c2f6e87328d.png">

Ye might not like the caption ... can remove if ye prefer not to have it.

- See https://github.com/jenkinsci/blueocean-plugin/pull/876
- See [JENKINS-41642](https://issues.jenkins-ci.org/browse/JENKINS-41642).

**Submitter checklist**
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests

**Reviewer checklist**
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

@reviewbybees
