### PR TITLE
Bug/use link for tablerow

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jenkins-cd/design-language",
   "jdlName": "jenkins-design-language",
-  "version": "0.0.129-SNAPSHOT-jm-a",
+  "version": "0.0.129-SNAPSHOT-jm-b",
   "description": "Styles, assets, and React classes for Jenkins Design Language",
   "main": "dist/js/components/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jenkins-cd/design-language",
   "jdlName": "jenkins-design-language",
-  "version": "0.0.129-SNAPSHOT",
+  "version": "0.0.129-SNAPSHOT-jm-a",
   "description": "Styles, assets, and React classes for Jenkins Design Language",
   "main": "dist/js/components/index.js",
   "scripts": {

--- a/src/js/components/jtable/TableRow.jsx
+++ b/src/js/components/jtable/TableRow.jsx
@@ -1,7 +1,8 @@
 // @flow
 
 import React, { Component, PropTypes, Children } from 'react';
-import { TableHeader } from './';
+import { Link } from 'react-router';
+import { TableHeader } from '../';
 import {
     TABLE_COLUMN_SPACING,
     TABLE_LEFT_RIGHT_PADDING
@@ -82,6 +83,7 @@ export class TableRow extends Component {
             children,
             columns,
             href,
+            linkTo,
             onClick,
         } = this.props;
 
@@ -94,16 +96,27 @@ export class TableRow extends Component {
 
         const newChildren = processChildren(children, columns);
 
-        let tagName = 'div';
+        let tagOrComponent = 'div';
         const props = {
             onClick,
-            href,
             className
         };
 
+        let rowIsALink = false;
+        
         if (typeof href === 'string' && href.length > 0) {
+            rowIsALink = true;
             // We switch to an <A> instead of <DIV> so the user can middle-click
-            tagName = 'a';
+            tagOrComponent = 'a';
+            props.href = href;
+        } else if (typeof linkTo === 'string' && linkTo.length > 0) {
+            rowIsALink = true;
+            // Use <Link> instead of <A> for local URLs because we don't know the base url here
+            tagOrComponent = Link;
+            props.to = linkTo;
+        } 
+        
+        if (rowIsALink) {
             classNames.push('JTable-row--href');
 
             if (useRollOver !== false) {
@@ -118,7 +131,7 @@ export class TableRow extends Component {
 
         props.className = classNames.join(' ');
 
-        return React.createElement(tagName, props, ...newChildren);
+        return React.createElement(tagOrComponent, props, ...newChildren);
     }
 }
 
@@ -127,6 +140,7 @@ TableRow.propTypes = {
     children: PropTypes.node,
     onClick: PropTypes.func,
     href: PropTypes.string,
+    linkTo: PropTypes.string,
     columns: PropTypes.array,
     useRollover: PropTypes.bool
 };

--- a/src/js/components/jtable/TableRow.jsx
+++ b/src/js/components/jtable/TableRow.jsx
@@ -14,6 +14,7 @@ type Props = {
     className?: string,
     children?: ReactChildren,
     href?: string,
+    linkTo?: string,
     onClick?: Function,
     columns: Array<ColumnDescription>,
     useRollover?: boolean
@@ -97,9 +98,9 @@ export class TableRow extends Component {
         const newChildren = processChildren(children, columns);
 
         let tagOrComponent = 'div';
-        const props = {
+        const props: Object = {
             onClick,
-            className
+            className,
         };
 
         let rowIsALink = false;

--- a/src/js/stories/JTableStories.jsx
+++ b/src/js/stories/JTableStories.jsx
@@ -1,7 +1,9 @@
 // @flow
 
 import React from 'react';
+import {Link} from 'react-router';
 import { storiesOf } from '@kadira/storybook';
+import WithContext from './WithContext';
 import {
     JTable,
     TableRow,
@@ -58,7 +60,17 @@ function container(...children) {
         margin: "1em"
     };
 
-    return React.createElement('div', {style}, ...children);
+    const ctx = {
+        router: {
+            createHref: x => "/createdHref" + x
+        }
+    };
+
+    return (
+        <WithContext context={ctx}>
+            {React.createElement('div', {style}, ...children)}
+        </WithContext>
+    );
 }
 
 function renderRow(rowData) {
@@ -149,6 +161,7 @@ function manual() {
     };
 
     return container(
+        <Link to="/relativeurl">This is in a link</Link>,
         <h3>Manual headers, row links</h3>,
         <JTable columns={columns} style={style}>
             <TableRow>
@@ -199,14 +212,14 @@ function manual() {
                 <TableCell>True</TableCell>
                 <TableCell>Charlie don't surf</TableCell>
             </TableRow>
-            <TableRow href="http://www.example.org/delta/">
+            <TableRow linkTo="/app-specific-url/foo">
                 <TableCell>False</TableCell>
                 <TableCell>False</TableCell>
                 <TableCell>False</TableCell>
                 <TableCell>False</TableCell>
                 <TableCell>False</TableCell>
                 <TableCell>True</TableCell>
-                <TableCell>YEARGH!</TableCell>
+                <TableCell>&lt;Link&gt;</TableCell>
             </TableRow>
         </JTable>,
         <h3>Some Links, some useRollover</h3>,


### PR DESCRIPTION
**Description**
- See [JENKINS-41833](https://issues.jenkins-ci.org/browse/JENKINS-41833).

Changes `<TableRow>` to add the ability to specify `linkTo="foo"` instead of `href="foo"` in which case it will make the row element using react-router's `Link` component instead of just `<div>` or `<a>`.

Suggested by @cliffmeyers ages ago, I am just a lazy jerk who kept putting it off until it broke some stuff 😁 