### PR TITLE
Bug/jenkins 43861 input param modal grows too wide

### DIFF
--- a/less/components/popups.less
+++ b/less/components/popups.less
@@ -94,6 +94,10 @@
 .Dialog-content-scroll {
     overflow: auto;
     flex-shrink: 1;
+    
+    .Dialog--medium-size & {
+        max-width: 464px; 
+    }
 }
 
 .Dialog-content-margin {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jenkins-cd/design-language",
   "jdlName": "jenkins-design-language",
-  "version": "0.0.133-SNAPSHOT",
+  "version": "0.0.134-SNAPSHOT",
   "description": "Styles, assets, and React classes for Jenkins Design Language",
   "main": "dist/js/components/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jenkins-cd/design-language",
   "jdlName": "jenkins-design-language",
-  "version": "0.0.131-SNAPSHOT",
+  "version": "0.0.131-SNAPSHOT-nicu",
   "description": "Styles, assets, and React classes for Jenkins Design Language",
   "main": "dist/js/components/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jenkins-cd/design-language",
   "jdlName": "jenkins-design-language",
-  "version": "0.0.131",
+  "version": "0.0.133-SNAPSHOT",
   "description": "Styles, assets, and React classes for Jenkins Design Language",
   "main": "dist/js/components/index.js",
   "scripts": {


### PR DESCRIPTION
**Description**
this adds the possibility of a Dialog component to have an optional max-width of 464px
- See [JENKINS-43861](https://issues.jenkins-ci.org/browse/JENKINS-43861).

**Submitter checklist**
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests

**Reviewer checklist**
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

@reviewbybees
