### PR TITLE
Bug/jenkins 45011 commit in run result header is not clickable

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jenkins-cd/design-language",
   "jdlName": "jenkins-design-language",
-  "version": "0.0.138-nicu",
+  "version": "0.0.138-nicu2",
   "description": "Styles, assets, and React classes for Jenkins Design Language",
   "main": "dist/js/components/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jenkins-cd/design-language",
   "jdlName": "jenkins-design-language",
-  "version": "0.0.138-SNAPSHOT",
+  "version": "0.0.138-nicu",
   "description": "Styles, assets, and React classes for Jenkins Design Language",
   "main": "dist/js/components/index.js",
   "scripts": {

--- a/src/js/components/CommitId.jsx
+++ b/src/js/components/CommitId.jsx
@@ -9,7 +9,7 @@ const GIT_HASH_REGEX = /\b[0-9a-f]{5,40}\b/;
  */
 export class CommitId extends Component {
     render() {
-        const {commitId, url} = this.props;
+        const {commitId, url, title} = this.props;
         let displayValue;
         if (GIT_HASH_REGEX.test(commitId)) {
             displayValue = commitId.substring(0, 7);
@@ -20,7 +20,7 @@ export class CommitId extends Component {
         }
 
         if (url) {
-            return (<a href={url} target="_blank" title="Opens commit in a new window">
+            return (<a href={url} target="_blank" title={title ? title : 'Opens commit in a new window'}>
                 <code className="hash">{displayValue}</code>
             </a>);
         }
@@ -32,4 +32,5 @@ export class CommitId extends Component {
 CommitId.propTypes = {
     commitId: PropTypes.string,
     url: PropTypes.string,
+    title: PropTypes.string,
 };

--- a/src/js/components/CommitId.jsx
+++ b/src/js/components/CommitId.jsx
@@ -31,4 +31,5 @@ export class CommitId extends Component {
 
 CommitId.propTypes = {
     commitId: PropTypes.string,
+    url: PropTypes.string,
 };

--- a/src/js/components/CommitId.jsx
+++ b/src/js/components/CommitId.jsx
@@ -9,7 +9,7 @@ const GIT_HASH_REGEX = /\b[0-9a-f]{5,40}\b/;
  */
 export class CommitId extends Component {
     render() {
-        const commitId = this.props.commitId;
+        const {commitId, url} = this.props;
         let displayValue;
         if (GIT_HASH_REGEX.test(commitId)) {
             displayValue = commitId.substring(0, 7);
@@ -18,6 +18,13 @@ export class CommitId extends Component {
         } else {
             displayValue = '–';
         }
+
+        if (url) {
+            return (<a href={url} target="_blank" title="Opens commit in a new window">
+                <code className="hash">{displayValue}</code>
+            </a>);
+        }
+
         return (<code className="hash">{displayValue}</code>);
     }
 }

--- a/test/js/components/CommitId-spec.jsx
+++ b/test/js/components/CommitId-spec.jsx
@@ -24,4 +24,10 @@ describe("CommitId", () => {
         assert.equal(wrapper.text().length, 7);
         assert.equal(wrapper.text(), '676b757');
     });
+
+    it("renders link when url prop is passed along", () => {
+        const wrapper = shallow(<CommitId commitId="123" url="link" />);
+        assert.isTrue(wrapper.is('a'));
+        assert.equal(wrapper.html(), '<a href="link" target="_blank" title="Opens commit in a new window"><code class="hash">123</code></a>');
+    });
 });

--- a/test/js/components/CommitId-spec.jsx
+++ b/test/js/components/CommitId-spec.jsx
@@ -27,7 +27,6 @@ describe("CommitId", () => {
 
     it("renders link when url prop is passed along", () => {
         const wrapper = shallow(<CommitId commitId="123" url="link" />);
-        assert.isTrue(wrapper.is('a'));
-        assert.equal(wrapper.html(), '<a href="link" target="_blank" title="Opens commit in a new window"><code class="hash">123</code></a>');
+        assert.isTrue(wrapper.is('a[href="link"]'));
     });
 });


### PR DESCRIPTION
**Description**
re-factor the CommitId component so it can accept an url and generate a link in case it is present
- See [JENKINS-45011](https://issues.jenkins-ci.org/browse/JENKINS-45011).

**Submitter checklist**
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests

**Reviewer checklist**
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

@reviewbybees
