### PR TITLE
fix: make children optional on SheetChildProps

### DIFF
--- a/components/Sheets/Sheets.test.tsx
+++ b/components/Sheets/Sheets.test.tsx
@@ -49,8 +49,8 @@ describe('Sheets', () => {
     });
 
     it('should test a sheet container', () => {
-        let onDismiss = jest.fn();
-        let sheet = <StoryContainerDetail title="My Story Title" onClose={onDismiss} />;
+        const onDismiss = jest.fn();
+        const sheet = <StoryContainerDetail title="My Story Title" onClose={onDismiss} />;
         const addSheet = () => {
             sheets.push(sheet);
         };

--- a/components/Sheets/Sheets.tsx
+++ b/components/Sheets/Sheets.tsx
@@ -5,18 +5,11 @@ import { ClickListener } from '@jdl2/onclick';
 import { KeyListener } from '@jdl2/keypress';
 
 export interface SheetChildProps {
-    children: React.ReactNode;
+    children?: React.ReactNode;
     // return false to prevent the sheet from being popped
     onClose?: () => void | boolean;
     title: JSX.Element | string;
 }
-
-export class Sheet extends React.Component<SheetChildProps> {
-    render() {
-        return this.props.children;
-    }
-}
-
 export interface SheetChild extends React.ReactElement<SheetChildProps> {
     title?: string;
     key: string | number | null;


### PR DESCRIPTION
This makes `children` optional on `SheetChildProps`.
Unit tests are already covering this change.

Which supports usage as:
```
sheets.push(<ApplicationDetail ... />);
```

Also, if I'm not mistaken `Sheet` class is not being used - I removed it.
@kzantow please confirm