### PR TITLE
fix: template for components

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
 package.json
 docs
 icons
+.templates

--- a/.templates/components/index.tsx
+++ b/.templates/components/index.tsx
@@ -6,7 +6,7 @@ export interface [componentName]Props extends CssProps {
 
 export function [componentName](props: [componentName]Props) {
     return (
-        <div className={css('[componentName]')}>
+        <div className={css(props, '[componentName]')}>
             [componentName]
         </div>
     );

--- a/components/Avatar/Avatar.tsx
+++ b/components/Avatar/Avatar.tsx
@@ -1,13 +1,8 @@
 import * as React from 'react';
 import { css, CssProps } from '@jdl2/css-util';
 
-export interface AvatarProps extends CssProps {
-}
+export interface AvatarProps extends CssProps {}
 
 export function Avatar(props: AvatarProps) {
-    return (
-        <div className={css('Avatar')}>
-            Avatar
-        </div>
-    );
+    return <div className={css(props, 'Avatar')}>Avatar</div>;
 }

--- a/components/Chip/Chip.tsx
+++ b/components/Chip/Chip.tsx
@@ -1,13 +1,8 @@
 import * as React from 'react';
 import { css, CssProps } from '@jdl2/css-util';
 
-export interface ChipProps extends CssProps {
-}
+export interface ChipProps extends CssProps {}
 
 export function Chip(props: ChipProps) {
-    return (
-        <div className={css('Chip')}>
-            Chip
-        </div>
-    );
+    return <div className={css(props, 'Chip')}>Chip</div>;
 }

--- a/components/InputText/InputText.scss
+++ b/components/InputText/InputText.scss
@@ -32,14 +32,14 @@
         border-color: $green;
         box-shadow: 0px 0px 0px 1px rgba($white, 0.5), 0px 0px 0px 3px rgba($green, 0.3);
     }
-}
 
-.LargeInputText {
-    font-size: 18px;
-    padding: $unit * 1.5;
-}
+    &.is-large {
+        font-size: 18px;
+        padding: $unit * 1.5;
+    }
 
-.SmallInputText {
-    font-size: 12px;
-    padding: $unit;
+    &.is-small {
+        font-size: 12px;
+        padding: $unit;
+    }
 }


### PR DESCRIPTION
There was a TS build error - when running `npm start`:

<img width="679" alt="screen shot 2018-08-21 at 09 11 19" src="https://user-images.githubusercontent.com/218816/44389480-e2f55480-a522-11e8-94fc-613f55797b24.png">

I have updated:
 - the `Avatar` & `Chip` components 
 - template for generating components (which has to be ignored by prettier)
 - and fix for size of InputText (just styles renamed to support `CssProps`)